### PR TITLE
Reword English README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,56 +13,56 @@ Make your smart phone smarter: tell it what to do under different situations.
 
 ### Smart automation
 
-Easer is an event-driven Android automation tool. It knows various (see below) events and YOU (the user) tell it what to do on what event (and even combine multiple events). Routine actions no longer need to be manually taken.
+Easer is an event-driven Android automation tool. It knows various events (see below) and YOU (the user) tell it what to do on what events (you can even combine multiple events). Thus, you no longer need to manually perform routine actions, or worry about forgetting to perform them.
 
-You can think Easer as a local version of IFTTT: Trigger actions or change settings (*Operation*s, bundled as *Profile*) in different situations (*Event*).
+You can think of Easer as a local version of IFTTT: trigger actions or change settings (*Operations*, bundled as *Profiles*) in different situations (*Events*).
 
 ### Inter-app coordination
 
-Easer is also a coordinator of inter-app actions (e.g. communications) -- send custom `Broadcast`s when receiving certain `Broadcast` (designed by YOU).
+Easer is also a coordinator of inter-app actions (e.g. communications) -- it can send custom `Broadcast`s upon receiving certain `Broadcast`s (designed by YOU).
 
-`Broadcast` (together with `Intent`) is the way Android provides for inter-app communication and signaling. Android doesn't do any carding nor provide any customization to this, so Easer would give it a try.
+`Broadcast` (together with `Intent`) is the way Android provides for inter-app communication and signaling.
 
 ### Custom Events
 
-You can chain *Event*s (set dependencies) as trees. This mechanism allows Easer to (somewhat) organize Events using boolean logics ("and", "or").
+You can chain *Events* (set dependencies) as trees. This mechanism allows Easer to (somewhat) organize *Events* using Boolean logic (e.g. "and", "or").
 
-Currently, Easer will perform Post-Order Traversal to load you Profile(s). In the near future, Easer will have more meticulous, more expressive and more intuitive categorization of *Event*s -- all these are controlled by YOU.
+Currently, Easer performs a post-order traversal to load your *Profiles*. In the near future, Easer will have more meticulous, expressive and intuitive categorization of *Events*.
 
-Also have a look at [wiki](https://github.com/renyuneyun/Easer/wiki), especially [FAQ](https://github.com/renyuneyun/Easer/wiki/FAQ).
+Also, have a look at the [wiki](https://github.com/renyuneyun/Easer/wiki), and especially the [FAQ](https://github.com/renyuneyun/Easer/wiki/FAQ).
 
 Examples
 ------
-* Turn your phone into Silent mode at 2 a.m.
-* Cancel Silent mode at 8 a.m. on weekdays, and at 10 a.m. on weekends
-* Turn WiFi on when approaching your home; turn WiFi off when leaving your home
+* Set your phone to silent mode at 2 a.m.
+* Cancel silent mode at 8 a.m. on weekdays, and at 10 a.m. on weekends
+* Turn on WiFi when approaching your home; turn off WiFi when leaving your home
 
 Supported functions
 --------
-Easer supports listening to many Android events (e.g. date/time, system status) and more (e.g. calendar); the supported operations include but not limited to changing Android settings, sending messages, executing commands.
+Easer supports listening to many Android events (e.g. date/time, system status, calendar). The supported operations include, but are not limited to, changing Android settings, sending messages, and executing commands.
 
-For a list of the features already supported, see [this page](https://renyuneyun.github.io/Easer/en/FEATURES).
+For a list of current features, see [this page](https://renyuneyun.github.io/Easer/en/FEATURES).
 
 Extending Easer
 ------
-Extending the functionality of Easer (by adding more *Event*s or *Operation*s) is really simple (and is becoming simpler).
+Extending the functionality of Easer (by adding more *Events* or *Operations*) is really simple (and is becoming simpler).
 
 Details are described in [this document](https://renyuneyun.github.io/Easer/en/EXTEND).
 
 Support Easer
 ------
-### Raising issues, Comment on issues and Solving issues
-If you encounter problems when using Easer, you could raise an issue. It is better (but not necessary) if you could give more details at first so I can pin it faster.  
-You could also open an issue if you think that some functions may need to be included in Easer.
+### Raising issues, commenting on issues and solving issues
+If you encounter problems when using Easer, you can submit an issue. The more detail you can provide, the better -- it will let the issue be pinned down faster.
+You can also open an issue if you think there are features that Easer should have.
 
-It is also welcome to comment on existing issues, either you believe you have the same problem (or idea), you could provide more information about it, or you don't agree with that. Discussion is always welcome.
+You are also welcome to comment on existing issues. If you believe you have the same problem (or idea), you can provide more information about it. Discussion is always welcome.
 
-In some situation (if you are a developer), you may possess the knowledge and time to solve some issues. You could fork the repo, do coding, and create pull requests so you code could be merged to the trunk and you get appreciated by others and also listed in the *Contributors* list.  
-It is also very welcome to create pull requests for issues not raised by others, but please first create an issue describing what you want to do (and that you are going to do it).
+If you are a developer, you may possess the knowledge and time to solve some issues. You can fork the repo, solve the problem, and create a pull request. Then, your code can be merged, and you can be appreciated by others and listed in the *Contributors* list.
+You're also welcome to create pull requests for issues not raised by others, but first, please create an issue describing what you want to do (and that you are going to do it).
 
 ### Donation
 
-If you would like to make any amount of donation, please see [DONATE](https://renyuneyun.github.io/Easer/en/DONATE).
+If you would like to make a donation, please see [DONATE](https://renyuneyun.github.io/Easer/en/DONATE).
 
 Any amount of help is appreciated.
 
@@ -74,12 +74,12 @@ Licensed under GPLv3+ (See LICENSE)
 
 ### Why GPL?
 
-The expected functions of Easer contain lots of tracks / captures of privacy (e.g. location, calendar), and would be able to access the Internet. We would never want a tool which is expected to better facilitate our lives to become a spying tool, so we must prevent that from happening as we can. The only way is to allow anyone to censor every part of Easer, which means to ensure Easer (and its derivated work, if any) to be opensource.  
-Because as of the design of Easer, each functionality will (in the furutre) become modules / plugins, maicious codes should also be prohibited from these parts, so we hope to rely on the feature of GPL (that derivated work should also be licensed under GPL) to enforce this.
+The expected functions of Easer require access to personal information (e.g. location, calendar) and networking capabilities. We would never want a tool that is expected to better facilitate our lives to spy on us, so we must prevent that from happening as best as we can. The only way to do this is to allow anyone to inspect every part of Easer, which is to say that Easer (and any derived works) must be made open source.
+Because of the design of Easer, functionality will eventually become modules / plugins. The GPL requires that derived works also be licensed under the GPL, and thus prevents malicious code from sneaking into these parts.
 
-In fact, ensuring derivated work / plugins to be **GPL** is unneeded, because we only need them to be **opensource**. However, GPL is the only license (known by me) which can enforce deriavted work / plugins to be opensource, so it's the only choice.
+In fact, ensuring that derived works / plugins are licensed under the **GPL** is unnecessary -- they only need to be **open source**. However, GPL is the only license (that I know of) which requires that derived works / plugins are open sourced, so it's the only choice.
 
-Third-party library
+Third-party libraries
 -----
 * [Logger](https://github.com/orhanobut/logger): Apache License v2
 * [android-flowlayout](https://github.com/ApmeM/android-flowlayout): Apache License v2

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -10,56 +10,56 @@ Make your smart phone smarter: tell it what to do under different situations.
 
 ### Smart automation
 
-Easer is an event-driven Android automation tool. It knows various (see below) events and YOU (the user) tell it what to do on what event (and even combine multiple events). Routine actions no longer need to be manually taken.
+Easer is an event-driven Android automation tool. It knows various events (see below) and YOU (the user) tell it what to do on what events (you can even combine multiple events). Thus, you no longer need to manually perform routine actions, or worry about forgetting to perform them.
 
-You can think Easer as a local version of IFTTT: Trigger actions or change settings (*Operation*s, bundled as *Profile*) in different situations (*Event*).
+You can think of Easer as a local version of IFTTT: trigger actions or change settings (*Operations*, bundled as *Profiles*) in different situations (*Events*).
 
 ### Inter-app coordination
 
-Easer is also a coordinator of inter-app actions (e.g. communications) -- send custom `Broadcast`s when receiving certain `Broadcast` (designed by YOU).
+Easer is also a coordinator of inter-app actions (e.g. communications) -- it can send custom `Broadcast`s upon receiving certain `Broadcast`s (designed by YOU).
 
-`Broadcast` (together with `Intent`) is the way Android provides for inter-app communication and signaling. Android doesn't do any carding nor provide any customization to this, so Easer would give it a try.
+`Broadcast` (together with `Intent`) is the way Android provides for inter-app communication and signaling.
 
 ### Custom Events
 
-You can chain *Event*s (set dependencies) as trees. This mechanism allows Easer to (somewhat) organize Events using boolean logics ("and", "or").
+You can chain *Events* (set dependencies) as trees. This mechanism allows Easer to (somewhat) organize *Events* using Boolean logic (e.g. "and", "or").
 
-Currently, Easer will perform Post-Order Traversal to load you Profile(s). In the near future, Easer will have more meticulous, more expressive and more intuitive categorization of *Event*s -- all these are controlled by YOU.
+Currently, Easer performs a post-order traversal to load your *Profiles*. In the near future, Easer will have more meticulous, expressive and intuitive categorization of *Events*.
 
-Also have a look at [wiki](https://github.com/renyuneyun/Easer/wiki), especially [FAQ](https://github.com/renyuneyun/Easer/wiki/FAQ).
+Also, have a look at the [wiki](https://github.com/renyuneyun/Easer/wiki), and especially the [FAQ](https://github.com/renyuneyun/Easer/wiki/FAQ).
 
 Examples
 ------
-* Turn your phone into Silent mode at 2 a.m.
-* Cancel Silent mode at 8 a.m. on weekdays, and at 10 a.m. on weekends
-* Turn WiFi on when approaching your home; turn WiFi off when leaving your home
+* Set your phone to silent mode at 2 a.m.
+* Cancel silent mode at 8 a.m. on weekdays, and at 10 a.m. on weekends
+* Turn on WiFi when approaching your home; turn off WiFi when leaving your home
 
 Supported functions
 --------
-Easer supports listening to many Android events (e.g. date/time, system status) and more (e.g. calendar); the supported operations include but not limited to changing Android settings, sending messages, executing commands.
+Easer supports listening to many Android events (e.g. date/time, system status, calendar). The supported operations include, but are not limited to, changing Android settings, sending messages, and executing commands.
 
-For a list of the features already supported, see [this page](https://renyuneyun.github.io/Easer/en/FEATURES).
+For a list of current features, see [this page](https://renyuneyun.github.io/Easer/en/FEATURES).
 
 Extending Easer
 ------
-Extending the functionality of Easer (by adding more *Event*s or *Operation*s) is really simple (and is becoming simpler).
+Extending the functionality of Easer (by adding more *Events* or *Operations*) is really simple (and is becoming simpler).
 
 Details are described in [this document](EXTEND.md).
 
 Support Easer
 ------
-### Raising issues, Comment on issues and Solving issues
-If you encounter problems when using Easer, you could raise an issue. It is better (but not necessary) if you could give more details at first so I can pin it faster.  
-You could also open an issue if you think that some functions may need to be included in Easer.
+### Raising issues, commenting on issues and solving issues
+If you encounter problems when using Easer, you can submit an issue. The more detail you can provide, the better -- it will let the issue be pinned down faster.
+You can also open an issue if you think there are features that Easer should have.
 
-It is also welcome to comment on existing issues, either you believe you have the same problem (or idea), you could provide more information about it, or you don't agree with that. Discussion is always welcome.
+You are also welcome to comment on existing issues. If you believe you have the same problem (or idea), you can provide more information about it. Discussion is always welcome.
 
-In some situation (if you are a developer), you may possess the knowledge and time to solve some issues. You could fork the repo, do coding, and create pull requests so you code could be merged to the trunk and you get appreciated by others and also listed in the *Contributors* list.  
-It is also very welcome to create pull requests for issues not raised by others, but please first create an issue describing what you want to do (and that you are going to do it).
+If you are a developer, you may possess the knowledge and time to solve some issues. You can fork the repo, solve the problem, and create a pull request. Then, your code can be merged, and you can be appreciated by others and listed in the *Contributors* list.
+You're also welcome to create pull requests for issues not raised by others, but first, please create an issue describing what you want to do (and that you are going to do it).
 
 ### Donation
 
-If you would like to make any amount of donation, please see [DONATE.md](DONATE.md).
+If you would like to make a donation, please see [DONATE.md](DONATE.md).
 
 Any amount of help is appreciated.
 
@@ -71,12 +71,12 @@ Licensed under GPLv3+ (See LICENSE)
 
 ### Why GPL?
 
-The expected functions of Easer contain lots of tracks / captures of privacy (e.g. location, calendar), and would be able to access the Internet. We would never want a tool which is expected to better facilitate our lives to become a spying tool, so we must prevent that from happening as we can. The only way is to allow anyone to censor every part of Easer, which means to ensure Easer (and its derivated work, if any) to be opensource.  
-Because as of the design of Easer, each functionality will (in the furutre) become modules / plugins, maicious codes should also be prohibited from these parts, so we hope to rely on the feature of GPL (that derivated work should also be licensed under GPL) to enforce this.
+The expected functions of Easer require access to personal information (e.g. location, calendar) and networking capabilities. We would never want a tool that is expected to better facilitate our lives to spy on us, so we must prevent that from happening as best as we can. The only way to do this is to allow anyone to inspect every part of Easer, which is to say that Easer (and any derived works) must be made open source.
+Because of the design of Easer, functionality will eventually become modules / plugins. The GPL requires that derived works also be licensed under the GPL, and thus prevents malicious code from sneaking into these parts.
 
-In fact, ensuring derivated work / plugins to be **GPL** is unneeded, because we only need them to be **opensource**. However, GPL is the only license (known by me) which can enforce deriavted work / plugins to be opensource, so it's the only choice.
+In fact, ensuring that derived works / plugins are licensed under the **GPL** is unnecessary -- they only need to be **open source**. However, GPL is the only license (that I know of) which requires that derived works / plugins are open sourced, so it's the only choice.
 
-Third-party library
+Third-party libraries
 -----
 * [Logger](https://github.com/orhanobut/logger): Apache License v2
 * [android-flowlayout](https://github.com/ApmeM/android-flowlayout): Apache License v2


### PR DESCRIPTION
I heavily reworded the English README to make it more clear and concise. I tried to stick to a direct translation of the Chinese version, but in some cases, I changed or removed sentences to make things clearer. If this is not preferable, I can undo those kinds of edits.

However, I believe the README as I've edited it is more clear. In fact, it could be made even more concise: the sections "Raising issues, commenting on issues and solving issues" and "Why GPL?" can be shortened or removed, since most people probably have a good idea of how issues and/or the GPL works. If not, then they can always be referred to an external guide—there's no need to explain it in this project's README.