### PR TITLE
Added the screen unlock condition to the screen event plugin

### DIFF
--- a/app/src/main/java/ryey/easer/plugins/event/screen/ScreenEventData.java
+++ b/app/src/main/java/ryey/easer/plugins/event/screen/ScreenEventData.java
@@ -31,7 +31,7 @@ public class ScreenEventData extends AbstractEventData {
     enum ScreenEvent {
         on,
         off,
-        unlocked
+        unlocked,
     }
 
     final ScreenEvent screenEvent;

--- a/app/src/main/java/ryey/easer/plugins/event/screen/ScreenEventData.java
+++ b/app/src/main/java/ryey/easer/plugins/event/screen/ScreenEventData.java
@@ -31,6 +31,7 @@ public class ScreenEventData extends AbstractEventData {
     enum ScreenEvent {
         on,
         off,
+        unlocked
     }
 
     final ScreenEvent screenEvent;

--- a/app/src/main/java/ryey/easer/plugins/event/screen/ScreenPluginViewFragment.java
+++ b/app/src/main/java/ryey/easer/plugins/event/screen/ScreenPluginViewFragment.java
@@ -34,7 +34,7 @@ import ryey.easer.commons.plugindef.ValidData;
 
 public class ScreenPluginViewFragment extends PluginViewFragment<ScreenEventData> {
 
-    RadioButton rb_screen_on, rb_screen_off;
+    RadioButton rb_screen_on, rb_screen_off, rb_screen_unlocked;
 
     @NonNull
     @Override
@@ -42,6 +42,7 @@ public class ScreenPluginViewFragment extends PluginViewFragment<ScreenEventData
         View view = inflater.inflate(R.layout.plugin_event__screen, container, false);
         rb_screen_on = view.findViewById(R.id.radioButton_screen_on);
         rb_screen_off = view.findViewById(R.id.radioButton_screen_off);
+        rb_screen_unlocked = view.findViewById(R.id.radioButton_screen_unlocked);
         return view;
     }
 
@@ -49,8 +50,10 @@ public class ScreenPluginViewFragment extends PluginViewFragment<ScreenEventData
     protected void _fill(@ValidData @NonNull ScreenEventData data) {
         if (data.screenEvent == ScreenEventData.ScreenEvent.on)
             rb_screen_on.setChecked(true);
-        else
+        else if (data.screenEvent == ScreenEventData.ScreenEvent.off)
             rb_screen_off.setChecked(true);
+        else if (data.screenEvent == ScreenEventData.ScreenEvent.unlocked)
+            rb_screen_unlocked.setChecked(true);
     }
 
     @ValidData
@@ -59,7 +62,9 @@ public class ScreenPluginViewFragment extends PluginViewFragment<ScreenEventData
     public ScreenEventData getData() throws InvalidDataInputException {
         if (rb_screen_on.isChecked())
             return new ScreenEventData(ScreenEventData.ScreenEvent.on);
-        else
+        else if (rb_screen_off.isChecked())
             return new ScreenEventData(ScreenEventData.ScreenEvent.off);
+        else
+            return new ScreenEventData(ScreenEventData.ScreenEvent.unlocked);
     }
 }

--- a/app/src/main/java/ryey/easer/plugins/event/screen/ScreenSlot.java
+++ b/app/src/main/java/ryey/easer/plugins/event/screen/ScreenSlot.java
@@ -38,6 +38,8 @@ public class ScreenSlot extends AbstractSlot<ScreenEventData> {
                 changeSatisfiedState(eventData.screenEvent == ScreenEventData.ScreenEvent.on);
             } else if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
                 changeSatisfiedState(eventData.screenEvent == ScreenEventData.ScreenEvent.off);
+            } else if (Intent.ACTION_USER_PRESENT.equals(intent.getAction())) {
+                changeSatisfiedState(eventData.screenEvent == ScreenEventData.ScreenEvent.unlocked);
             }
         }
     };
@@ -53,6 +55,7 @@ public class ScreenSlot extends AbstractSlot<ScreenEventData> {
         intentFilter = new IntentFilter();
         intentFilter.addAction(Intent.ACTION_SCREEN_ON);
         intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
+        intentFilter.addAction(Intent.ACTION_USER_PRESENT);
     }
 
     @Override

--- a/app/src/main/res/layout/plugin_event__screen.xml
+++ b/app/src/main/res/layout/plugin_event__screen.xml
@@ -43,5 +43,12 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/ev_screen_off" />
+
+        <RadioButton
+            android:id="@+id/radioButton_screen_unlocked"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/ev_screen_unlocked" />
     </RadioGroup>
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/plugins.xml
+++ b/app/src/main/res/values/plugins.xml
@@ -94,6 +94,7 @@
     <string name="ev_screen_text_screen_is">When screen is…</string>
     <string name="ev_screen_on">On</string>
     <string name="ev_screen_off">Off</string>
+    <string name="ev_screen_unlocked">Unlocked</string>
 
     <string name="operation_wifi">WiFi</string>
     <string name="operation_cellular">Mobile data</string>


### PR DESCRIPTION
The screen event plugin can now respond to the screen unlock event. The screen unlock event is triggered by the intent `ACTION_USER_PRESENT` as described in the Android [documentation](https://developer.android.com/reference/android/content/Intent#ACTION_USER_PRESENT).

I added a radio button titled "unlocked" under the other buttons. Translations for this button other than English are not provided.

The functionality was rapidly tested and found working. Searching online shows the intent `ACTION_USER_PRESENT` might be sometimes problematic: when there is a different lock screen installed or if the lock screen is disabled.