### PR TITLE
Add Termux Operation plugin

### DIFF
--- a/app/src/androidTest/java/ryey/easer/plugins/operation/termux/TermuxOperationDataTest.java
+++ b/app/src/androidTest/java/ryey/easer/plugins/operation/termux/TermuxOperationDataTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.plugins.operation.termux;
+
+import android.os.Parcel;
+
+import org.junit.Test;
+
+import ryey.easer.plugins.TestHelper;
+import ryey.easer.plugins.operation.command.CommandOperationData;
+import ryey.easer.plugins.operation.command.CommandOperationDataFactory;
+
+import static org.junit.Assert.assertEquals;
+
+public class TermuxOperationDataTest {
+
+    @Test
+    public void testParcel() {
+        TermuxOperationData dummyData = new TermuxOperationDataFactory().dummyData();
+        Parcel parcel = TestHelper.writeToParcel(dummyData);
+        CommandOperationData parceledData = CommandOperationData.CREATOR.createFromParcel(parcel);
+        assertEquals(dummyData, parceledData);
+    }
+
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,8 @@
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+    <uses-permission android:name="com.termux.permission.TERMUX_SERVICE" />
+
 
     <application
         android:name=".EaserApplication"

--- a/app/src/main/java/ryey/easer/plugins/LocalPluginRegistry.java
+++ b/app/src/main/java/ryey/easer/plugins/LocalPluginRegistry.java
@@ -89,6 +89,7 @@ import ryey.easer.plugins.operation.send_notification.SendNotificationOperationP
 import ryey.easer.plugins.operation.send_sms.SendSmsOperationPlugin;
 import ryey.easer.plugins.operation.state_control.StateControlOperationPlugin;
 import ryey.easer.plugins.operation.synchronization.SynchronizationOperationPlugin;
+import ryey.easer.plugins.operation.termux.TermuxOperationPlugin;
 import ryey.easer.plugins.operation.ui_mode.UiModeOperationPlugin;
 import ryey.easer.plugins.operation.volume.VolumeOperationPlugin;
 import ryey.easer.plugins.operation.wifi.WifiOperationPlugin;
@@ -163,6 +164,11 @@ final public class LocalPluginRegistry {
         operation().registerPlugin(LaunchAppOperationPlugin.class);
         operation().registerPlugin(UiModeOperationPlugin.class);
         //TODO: write more plugins
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+//            TODO define it as external plugin ? or check if termux is installed
+            operation().registerPlugin(TermuxOperationPlugin.class);
+
+        }
     }
 
     private static final LocalPluginRegistry instance = new LocalPluginRegistry();

--- a/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxConstant.java
+++ b/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxConstant.java
@@ -1,0 +1,12 @@
+package ryey.easer.plugins.operation.termux;
+
+public class TermuxConstant {
+
+    public static final String URI_SCHEME = "com.termux.file";
+    public static final String ACTION_NAME = "com.termux.service_execute";
+    public static final String PACKAGE_NAME = "com.termux";
+    public static final String CLASS_NAME = "com.termux.app.TermuxService";
+    public static final String EXTRA_BACKGROUND = "com.termux.execute.background";
+    public static final String EXTRA_INITIAL_URI = "content://com.termux.documents/document/";
+    public static final String COLUMN_ID = "document_id";
+}

--- a/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxLoader.java
+++ b/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxLoader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.plugins.operation.termux;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.support.annotation.NonNull;
+
+import com.orhanobut.logger.Logger;
+
+import java.io.File;
+import java.io.IOException;
+
+import ryey.easer.Utils;
+import ryey.easer.commons.local_plugin.ValidData;
+import ryey.easer.plugins.operation.OperationLoader;
+import ryey.easer.plugins.reusable.PluginHelper;
+
+import static ryey.easer.plugins.operation.termux.TermuxConstant.ACTION_NAME;
+import static ryey.easer.plugins.operation.termux.TermuxConstant.CLASS_NAME;
+import static ryey.easer.plugins.operation.termux.TermuxConstant.EXTRA_BACKGROUND;
+import static ryey.easer.plugins.operation.termux.TermuxConstant.PACKAGE_NAME;
+import static ryey.easer.plugins.operation.termux.TermuxConstant.URI_SCHEME;
+
+public class TermuxLoader extends OperationLoader<TermuxOperationData> {
+    public TermuxLoader(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean load(@ValidData @NonNull TermuxOperationData data) {
+        boolean success = true;
+        String script = Utils.format(data.get());
+        File f = new File(script);
+        Logger.i("Running Termux command: " + f.getAbsolutePath());
+        Uri scriptUri = new Uri.Builder().scheme(URI_SCHEME).path(f.getAbsolutePath()).build();
+        Intent executeIntent = new Intent(ACTION_NAME, scriptUri);
+        executeIntent.setClassName(PACKAGE_NAME, CLASS_NAME);
+        executeIntent.putExtra(EXTRA_BACKGROUND, true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // https://developer.android.com/about/versions/oreo/background.html
+            context.startForegroundService(executeIntent);
+        } else {
+            context.startService(executeIntent);
+        }
+        return success;
+    }
+}

--- a/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxOperationData.java
+++ b/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxOperationData.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.plugins.operation.termux;
+
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+
+import ryey.easer.Utils;
+import ryey.easer.commons.local_plugin.IllegalStorageDataException;
+import ryey.easer.commons.local_plugin.dynamics.SolidDynamicsAssignment;
+import ryey.easer.commons.local_plugin.operationplugin.OperationData;
+import ryey.easer.plugin.PluginDataFormat;
+import ryey.easer.plugins.operation.StringOperationData;
+
+public class TermuxOperationData extends StringOperationData {
+
+    TermuxOperationData(String script) {
+        super(script);
+    }
+
+    TermuxOperationData(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        super(data, format, version);
+    }
+
+    public static final Creator<TermuxOperationData> CREATOR
+            = new Creator<TermuxOperationData>() {
+        public TermuxOperationData createFromParcel(Parcel in) {
+            return new TermuxOperationData(in);
+        }
+
+        public TermuxOperationData[] newArray(int size) {
+            return new TermuxOperationData[size];
+        }
+    };
+
+    private TermuxOperationData(Parcel in) {
+        super(in);
+    }
+
+    @NonNull
+    @Override
+    public OperationData applyDynamics(SolidDynamicsAssignment dynamicsAssignment) {
+        return new TermuxOperationData(Utils.applyDynamics(text, dynamicsAssignment));
+    }
+}

--- a/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxOperationDataFactory.java
+++ b/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxOperationDataFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.plugins.operation.termux;
+
+import android.support.annotation.NonNull;
+
+import ryey.easer.commons.local_plugin.IllegalStorageDataException;
+import ryey.easer.commons.local_plugin.ValidData;
+import ryey.easer.commons.local_plugin.operationplugin.OperationDataFactory;
+import ryey.easer.plugin.PluginDataFormat;
+
+class TermuxOperationDataFactory implements OperationDataFactory<TermuxOperationData> {
+    @NonNull
+    @Override
+    public Class<TermuxOperationData> dataClass() {
+        return TermuxOperationData.class;
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public TermuxOperationData dummyData() {
+        return new TermuxOperationData("/sdcard/mycmd_file");
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public TermuxOperationData parse(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        return new TermuxOperationData(data, format, version);
+    }
+}

--- a/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxOperationPlugin.java
+++ b/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxOperationPlugin.java
@@ -17,7 +17,7 @@
  * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ryey.easer.plugins.operation.command;
+package ryey.easer.plugins.operation.termux;
 
 import android.app.Activity;
 import android.content.Context;
@@ -33,17 +33,17 @@ import ryey.easer.plugin.operation.Category;
 import ryey.easer.plugins.operation.OperationLoader;
 import ryey.easer.plugins.reusable.PluginHelper;
 
-public class CommandOperationPlugin implements OperationPlugin<CommandOperationData> {
+public class TermuxOperationPlugin implements OperationPlugin<TermuxOperationData> {
 
     @NonNull
     @Override
     public String id() {
-        return "command";
+        return "termux";
     }
 
     @Override
     public int name() {
-        return R.string.operation_command;
+        return R.string.operation_termux;
     }
 
     @Override
@@ -70,30 +70,37 @@ public class CommandOperationPlugin implements OperationPlugin<CommandOperationD
 
     @Override
     public boolean checkPermissions(@NonNull Context context) {
-        return true;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return PluginHelper.checkPermission(context, "com.termux.permission.TERMUX_SERVICE");
+        } else {
+            return true;
+        }
     }
 
     @Override
     public void requestPermissions(@NonNull Activity activity, int requestCode) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PluginHelper.requestPermission(activity, requestCode, "com.termux.permission.TERMUX_SERVICE");
+        }
     }
 
     @NonNull
     @Override
-    public OperationDataFactory<CommandOperationData> dataFactory() {
-        return new CommandOperationDataFactory();
+    public OperationDataFactory<TermuxOperationData> dataFactory() {
+        return new TermuxOperationDataFactory();
 
     }
 
     @NonNull
     @Override
-    public PluginViewFragmentInterface<CommandOperationData> view() {
-        return new CommandPluginViewFragment();
+    public PluginViewFragmentInterface<TermuxOperationData> view() {
+        return new TermuxPluginViewFragment();
     }
 
     @NonNull
     @Override
-    public OperationLoader<CommandOperationData> loader(@NonNull Context context) {
-        return new CommandLoader(context);
+    public OperationLoader<TermuxOperationData> loader(@NonNull Context context) {
+        return new TermuxLoader(context);
     }
 
 }

--- a/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxPluginViewFragment.java
+++ b/app/src/main/java/ryey/easer/plugins/operation/termux/TermuxPluginViewFragment.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.plugins.operation.termux;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+
+import java.io.File;
+
+import ryey.easer.R;
+import ryey.easer.commons.local_plugin.InvalidDataInputException;
+import ryey.easer.commons.local_plugin.ValidData;
+import ryey.easer.plugins.PluginViewFragment;
+
+import static android.provider.DocumentsContract.EXTRA_INITIAL_URI;
+import static ryey.easer.plugins.operation.termux.TermuxConstant.COLUMN_ID;
+
+public class TermuxPluginViewFragment extends PluginViewFragment<TermuxOperationData> {
+    private static final int READ_REQUEST_CODE = 42;
+
+    private Button scriptSelectorButton;
+
+    @NonNull
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.plugin_operation__termux, container, false);
+        scriptSelectorButton = view.findViewById(R.id.scrip_selector);
+        scriptSelectorButton.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+                    Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                    intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, TermuxConstant.EXTRA_INITIAL_URI);
+
+
+                    intent.addCategory(Intent.CATEGORY_OPENABLE);
+                    intent.setType("*/*");
+                    startActivityForResult(intent, READ_REQUEST_CODE);
+                }
+
+            }
+        });
+        return view;
+    }
+
+    @Override
+    protected void _fill(@ValidData @NonNull TermuxOperationData data) {
+        String script = data.get();
+        scriptSelectorButton.setText(script);
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public TermuxOperationData getData() throws InvalidDataInputException {
+        return new TermuxOperationData(scriptSelectorButton.getText().toString());
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent resultData) {
+        if (requestCode == READ_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            Uri uri = null;
+            if (resultData != null) {
+                uri = resultData.getData();
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                    Cursor cursor = getActivity().getContentResolver()
+                            .query(uri, null, null, null, null, null);
+                    try {
+                        if (cursor != null && cursor.moveToFirst()) {
+                            File file = new File(cursor.getString(cursor.getColumnIndex(COLUMN_ID)));
+                            scriptSelectorButton.setText(file.getAbsolutePath());
+                        }
+                    } finally {
+                        cursor.close();
+                    }
+                } else {
+                    // clean the uri to be usable as a termux script
+                    File file = new File(uri.getPath().substring("/document".length()));
+                    scriptSelectorButton.setText(file.getAbsolutePath());
+
+                }
+
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/plugin_operation__termux.xml
+++ b/app/src/main/res/layout/plugin_operation__termux.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/scrip_selector"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/operation_termux_button_text" />
+</LinearLayout>

--- a/app/src/main/res/values/plugins.xml
+++ b/app/src/main/res/values/plugins.xml
@@ -174,6 +174,8 @@
     <string name="label_operation_ringer_mode_notification_listener_service">Silent Mode Switcher</string>
 
     <string name="operation_command">Run commands</string>
+    <string name="operation_termux">Run Termux script</string>
+    <string name="operation_termux_button_text">Click to select the script</string>
     <string name="operation_hotspot">Hotspot</string>
     <string name="operation_synchronization">Account synchronization</string>
 


### PR DESCRIPTION
I add an operation which allows to select a script which will be run as a background task on termux.

This plugin is related to https://github.com/termux/termux-app/pull/1029 as it needs to get the associate right to launch termux script (like termux-widget or termux-tasker do)