### PR TITLE
removes override for method event in ConnectivityUSourceSkill to fix #237

### DIFF
--- a/app/src/main/java/ryey/easer/skills/usource/connectivity/ConnectivityUSourceSkill.java
+++ b/app/src/main/java/ryey/easer/skills/usource/connectivity/ConnectivityUSourceSkill.java
@@ -99,11 +99,4 @@ public class ConnectivityUSourceSkill implements USourceSkill<ConnectivityEventD
     public Tracker<ConnectivityEventData> tracker(@NonNull Context context, @NonNull ConnectivityEventData data, @NonNull PendingIntent event_positive, @NonNull PendingIntent event_negative) {
         return new ConnectivityTracker(context, data, event_positive, event_negative);
     }
-
-    @Deprecated
-    @Override
-    public EventSkill<ConnectivityEventData> event() {
-        return ((USourceSkill<ConnectivityEventData>) this).event();
-    }
-
 }


### PR DESCRIPTION
It seems the implementation of the ConnectivityUSourceSkill causes #237 .
The implementation overrides the deprecated event() method here and calls itself infinite! These leads to the overflow.
I just removed the override and the app is working again on my phone.
Is this possible or was this override needed?