### PR TITLE
add test for AbstractEditDataActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation "ch.acra:acra-toast:$acraVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.json:json:20190722'
+    testImplementation "org.mockito:mockito-core:3.2.4"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
 }

--- a/app/src/test/java/ryey/easer/core/ui/data/AbstractEditDataActivityTest.kt
+++ b/app/src/test/java/ryey/easer/core/ui/data/AbstractEditDataActivityTest.kt
@@ -1,0 +1,61 @@
+package ryey.easer.core.ui.data
+
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.Mockito.*
+import ryey.easer.commons.local_skill.InvalidDataInputException
+import ryey.easer.commons.local_skill.conditionskill.ConditionData
+import ryey.easer.core.data.ConditionStructure
+import ryey.easer.core.data.storage.ConditionDataStorage
+
+class StubEditDataActivity(private val thowException: Boolean) : AbstractEditDataActivity<ConditionStructure, ConditionDataStorage>() {
+
+    private var mockData: ConditionData = mock(ConditionData::class.java)
+    private var mockStorage: ConditionDataStorage = mock(ConditionDataStorage::class.java)
+
+    init {
+        `when`(mockData.isValid).thenReturn(true)
+        `when`(mockStorage.add(any<ConditionStructure>())).thenReturn(true)
+        purpose = EditDataProto.Purpose.add
+        storage = mockStorage
+    }
+
+    override fun retDataStorage(): ConditionDataStorage {
+          throw NotImplementedError()
+    }
+
+    override fun contentViewRes(): Int {
+        throw NotImplementedError()
+    }
+
+    override fun init() {
+        throw NotImplementedError()
+    }
+
+    override fun loadFromData(data: ConditionStructure?) {
+    }
+
+    override fun saveToData(): ConditionStructure {
+        if (thowException)
+            throw Exception()
+        return ConditionStructure("test", mockData)
+    }
+
+    override fun title(): String {
+        throw NotImplementedError()
+    }
+}
+
+class AbstractEditDataActivityTest {
+    @Test
+    fun testTryPersistChangeReturnsInvalidDataInputExceptionWhenSaveToDataThrowsException() {
+        val editDataActivity = StubEditDataActivity(true)
+        assertEquals(InvalidDataInputException(java.lang.Exception()).toString(), editDataActivity.tryPersistChange().toString())
+    }
+
+    @Test
+    fun testTryPersistChangeReturnsNullWhenSuccess() {
+        val editDataActivity = StubEditDataActivity(false)
+        assertNull(editDataActivity.tryPersistChange())
+    }
+}


### PR DESCRIPTION
Please review.

Method `saveToData` was throwing unchecked Exception (Implementation is in Kotlin)

Fix was simple, but the test...
 

  - I use mockito to mock `ConditionData` and `ConditionStructure`.
  - I didn't find how to mock abstract class, so I made simple stub for `AbstractEditDataActivity`. It throws an Exception.
 - But this was not enough. `persistChange` call `Toast.makeText`. To mock it I use robolectric.