### PR TITLE
Add startActivity and startService - operations

### DIFF
--- a/app/src/androidTest/java/ryey/easer/skills/operation/intent/IntentOperationDataTest.java
+++ b/app/src/androidTest/java/ryey/easer/skills/operation/intent/IntentOperationDataTest.java
@@ -17,7 +17,7 @@
  * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ryey.easer.skills.operation.broadcast;
+package ryey.easer.skills.operation.intent;
 
 import android.os.Parcel;
 
@@ -29,23 +29,23 @@ import ryey.easer.skills.TestHelper;
 
 import static org.junit.Assert.assertEquals;
 
-public class BroadcastOperationDataTest {
+public class IntentOperationDataTest {
 
     @Test
     public void testParcel() {
-        BroadcastOperationData dummyData = new BroadcastOperationDataFactory().dummyData();
+        IntentOperationData dummyData = new IntentOperationDataFactory().dummyData();
         Parcel parcel = TestHelper.writeToParcel(dummyData);
-        BroadcastOperationData parceledData = BroadcastOperationData.CREATOR.createFromParcel(parcel);
+        IntentOperationData parceledData = IntentOperationData.CREATOR.createFromParcel(parcel);
         assertEquals(dummyData, parceledData);
     }
 
     @Test
     public void testSerialize() throws Exception {
-        BroadcastOperationDataFactory factory = new BroadcastOperationDataFactory();
-        BroadcastOperationData dummyData = factory.dummyData();
+        IntentOperationDataFactory factory = new IntentOperationDataFactory();
+        IntentOperationData dummyData = factory.dummyData();
         for (PluginDataFormat format : PluginDataFormat.values()) {
             String serialized_data = dummyData.serialize(format);
-            BroadcastOperationData parsed_data = factory.parse(serialized_data, format, C.VERSION_CURRENT);
+            IntentOperationData parsed_data = factory.parse(serialized_data, format, C.VERSION_CURRENT);
             assertEquals(dummyData, parsed_data);
         }
     }

--- a/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
+++ b/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
@@ -62,6 +62,9 @@ import ryey.easer.skills.operation.cellular.CellularOperationSkill;
 import ryey.easer.skills.operation.command.CommandOperationSkill;
 import ryey.easer.skills.operation.hotspot.HotspotOperationSkill;
 import ryey.easer.skills.operation.http_request.HttpRequestOperationSkill;
+import ryey.easer.skills.operation.intent.operations.ActivityOperationSkill;
+import ryey.easer.skills.operation.intent.operations.BroadcastOperationSkill;
+import ryey.easer.skills.operation.intent.operations.ServiceOperationSkill;
 import ryey.easer.skills.operation.launch_app.LaunchAppOperationSkill;
 import ryey.easer.skills.operation.media_control.MediaControlOperationSkill;
 import ryey.easer.skills.operation.network_transmission.NetworkTransmissionOperationSkill;
@@ -151,7 +154,6 @@ final public class LocalSkillRegistry {
         operation().registerSkill(AlarmOperationSkill.class);
         operation().registerSkill(BluetoothOperationSkill.class);
         operation().registerSkill(BrightnessOperationSkill.class);
-        operation().registerSkill(IntentOperationSkill.class);
         operation().registerSkill(CellularOperationSkill.class);
         operation().registerSkill(CommandOperationSkill.class);
         operation().registerSkill(LaunchAppOperationSkill.class);
@@ -169,6 +171,9 @@ final public class LocalSkillRegistry {
         operation().registerSkill(UiModeOperationSkill.class);
         operation().registerSkill(VolumeOperationSkill.class);
         operation().registerSkill(WifiOperationSkill.class);
+        operation().registerSkill(ActivityOperationSkill.class);
+        operation().registerSkill(BroadcastOperationSkill.class);
+        operation().registerSkill(ServiceOperationSkill.class);
 
         //TODO: write more skills
     }

--- a/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
+++ b/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
@@ -57,7 +57,7 @@ import ryey.easer.skills.operation.airplane_mode.AirplaneModeOperationSkill;
 import ryey.easer.skills.operation.alarm.AlarmOperationSkill;
 import ryey.easer.skills.operation.bluetooth.BluetoothOperationSkill;
 import ryey.easer.skills.operation.brightness.BrightnessOperationSkill;
-import ryey.easer.skills.operation.broadcast.BroadcastOperationSkill;
+import ryey.easer.skills.operation.intent.IntentOperationSkill;
 import ryey.easer.skills.operation.cellular.CellularOperationSkill;
 import ryey.easer.skills.operation.command.CommandOperationSkill;
 import ryey.easer.skills.operation.hotspot.HotspotOperationSkill;
@@ -151,7 +151,7 @@ final public class LocalSkillRegistry {
         operation().registerSkill(AlarmOperationSkill.class);
         operation().registerSkill(BluetoothOperationSkill.class);
         operation().registerSkill(BrightnessOperationSkill.class);
-        operation().registerSkill(BroadcastOperationSkill.class);
+        operation().registerSkill(IntentOperationSkill.class);
         operation().registerSkill(CellularOperationSkill.class);
         operation().registerSkill(CommandOperationSkill.class);
         operation().registerSkill(LaunchAppOperationSkill.class);

--- a/app/src/main/java/ryey/easer/skills/operation/broadcast/BroadcastLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/broadcast/BroadcastLoader.java
@@ -27,37 +27,19 @@ import androidx.annotation.NonNull;
 import ryey.easer.Utils;
 import ryey.easer.commons.local_skill.ValidData;
 import ryey.easer.skills.operation.OperationLoader;
+import ryey.easer.skills.operation.intent.IntentData;
+import ryey.easer.skills.operation.intent.IntentLoader;
+import ryey.easer.skills.operation.intent.IntentOperationData;
 
-public class BroadcastLoader extends OperationLoader<BroadcastOperationData> {
+public class BroadcastLoader extends IntentLoader<IntentOperationData> {
     public BroadcastLoader(Context context) {
         super(context);
     }
 
     @Override
-    public void _load(@ValidData @NonNull BroadcastOperationData data, @NonNull OnResultCallback callback) {
-        IntentData iData = data.data;
-        Intent intent = new Intent();
-        intent.setAction(iData.action);
-        if (iData.category != null)
-            for (String category : iData.category) {
-                intent.addCategory(category);
-            }
-        boolean hasType = false, hasData = false;
-        if (!Utils.isBlank(iData.type))
-            hasType = true;
-        if (iData.data != null && !Utils.isBlank(iData.data.toString()))
-            hasData = true;
-        if (hasType && hasData) {
-            intent.setDataAndType(iData.data, iData.type);
-        } else if (hasType) {
-            intent.setType(iData.type);
-        } else if (hasData) {
-            intent.setData(iData.data);
-        }
-        if (iData.extras != null) {
-            intent.putExtras(iData.extras.asBundle());
-        }
-        context.sendBroadcast(intent);
+    public void _load(@ValidData @NonNull IntentOperationData data, @NonNull OnResultCallback callback) {
+
+        context.sendBroadcast(this.getIntent(data));
         callback.onResult(true);
     }
 }

--- a/app/src/main/java/ryey/easer/skills/operation/broadcast/BroadcastOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/broadcast/BroadcastOperationSkill.java
@@ -1,40 +1,15 @@
-/*
- * Copyright (c) 2016 - 2019 Rui Zhao <renyuneyun@gmail.com>
- *
- * This file is part of Easer.
- *
- * Easer is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Easer is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package ryey.easer.skills.operation.broadcast;
 
-import android.app.Activity;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import ryey.easer.R;
-import ryey.easer.commons.local_skill.SkillView;
-import ryey.easer.commons.local_skill.operationskill.OperationDataFactory;
-import ryey.easer.commons.local_skill.operationskill.OperationSkill;
-import ryey.easer.commons.local_skill.operationskill.PrivilegeUsage;
-import ryey.easer.plugin.operation.Category;
 import ryey.easer.skills.operation.OperationLoader;
+import ryey.easer.skills.operation.intent.IntentOperationData;
+import ryey.easer.skills.operation.intent.IntentOperationSkill;
 
-public class BroadcastOperationSkill implements OperationSkill<BroadcastOperationData> {
-
+public class BroadcastOperationSkill extends IntentOperationSkill {
     @NonNull
     @Override
     public String id() {
@@ -46,56 +21,10 @@ public class BroadcastOperationSkill implements OperationSkill<BroadcastOperatio
         return R.string.operation_broadcast;
     }
 
-    @Override
-    public boolean isCompatible(@NonNull final Context context) {
-        return true;
-    }
 
     @NonNull
     @Override
-    public PrivilegeUsage privilege() {
-        return PrivilegeUsage.no_root;
-    }
-
-    @Override
-    public int maxExistence() {
-        return 0;
-    }
-
-    @NonNull
-    @Override
-    public Category category() {
-        return Category.android;
-    }
-
-    @Nullable
-    @Override
-    public Boolean checkPermissions(@NonNull Context context) {
-        return null;
-    }
-
-    @Override
-    public void requestPermissions(@NonNull Activity activity, int requestCode) {
-
-    }
-
-    @NonNull
-    @Override
-    public OperationDataFactory<BroadcastOperationData> dataFactory() {
-        return new BroadcastOperationDataFactory();
-
-    }
-
-    @NonNull
-    @Override
-    public SkillView<BroadcastOperationData> view() {
-        return new BroadcastSkillViewFragment();
-    }
-
-    @NonNull
-    @Override
-    public OperationLoader<BroadcastOperationData> loader(@NonNull Context context) {
+    public OperationLoader<IntentOperationData> loader(@NonNull Context context) {
         return new BroadcastLoader(context);
     }
-
 }

--- a/app/src/main/java/ryey/easer/skills/operation/intent/IntentData.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/IntentData.java
@@ -17,7 +17,7 @@
  * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ryey.easer.skills.operation.broadcast;
+package ryey.easer.skills.operation.intent;
 
 import android.net.Uri;
 import android.os.Parcel;

--- a/app/src/main/java/ryey/easer/skills/operation/intent/IntentLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/IntentLoader.java
@@ -1,0 +1,41 @@
+package ryey.easer.skills.operation.intent;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.Utils;
+import ryey.easer.commons.local_skill.ValidData;
+
+public abstract class IntentLoader<T extends IntentOperationData> extends ryey.easer.skills.operation.OperationLoader<T> {
+    public IntentLoader(@NonNull Context context) {
+        super(context);
+    }
+
+    protected Intent getIntent(@ValidData @NonNull IntentOperationData data) {
+        IntentData iData = data.data;
+        Intent intent = new Intent();
+        intent.setAction(iData.action);
+        if (iData.category != null)
+            for (String category : iData.category) {
+                intent.addCategory(category);
+            }
+        boolean hasType = false, hasData = false;
+        if (!Utils.isBlank(iData.type))
+            hasType = true;
+        if (iData.data != null && !Utils.isBlank(iData.data.toString()))
+            hasData = true;
+        if (hasType && hasData) {
+            intent.setDataAndType(iData.data, iData.type);
+        } else if (hasType) {
+            intent.setType(iData.type);
+        } else if (hasData) {
+            intent.setData(iData.data);
+        }
+        if (iData.extras != null) {
+            intent.putExtras(iData.extras.asBundle());
+        }
+        return intent;
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/intent/IntentOperationData.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/IntentOperationData.java
@@ -1,23 +1,4 @@
-/*
- * Copyright (c) 2016 - 2019 Rui Zhao <renyuneyun@gmail.com>
- *
- * This file is part of Easer.
- *
- * Easer is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Easer is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-package ryey.easer.skills.operation.broadcast;
+package ryey.easer.skills.operation.intent;
 
 import android.net.Uri;
 import android.os.Parcel;
@@ -42,8 +23,9 @@ import ryey.easer.commons.local_skill.operationskill.OperationData;
 import ryey.easer.plugin.PluginDataFormat;
 import ryey.easer.skills.operation.ExtraItem;
 import ryey.easer.skills.operation.Extras;
+import ryey.easer.skills.operation.intent.IntentOperationData;
 
-public class BroadcastOperationData implements OperationData {
+public class IntentOperationData implements OperationData {
     private static final String ns = null;
 
     private static final String ACTION = "action";
@@ -54,11 +36,11 @@ public class BroadcastOperationData implements OperationData {
 
     IntentData data = new IntentData();
 
-    BroadcastOperationData(IntentData data) {
+    IntentOperationData(IntentData data) {
         this.data = data;
     }
 
-    BroadcastOperationData(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+    IntentOperationData(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
         parse(data, format, version);
     }
 
@@ -153,9 +135,9 @@ public class BroadcastOperationData implements OperationData {
     public boolean equals(Object obj) {
         if (obj == this)
             return true;
-        if (!(obj instanceof BroadcastOperationData))
+        if (!(obj instanceof IntentOperationData))
             return false;
-        return data.equals(((BroadcastOperationData) obj).data);
+        return data.equals(((IntentOperationData) obj).data);
     }
 
     @Override
@@ -168,18 +150,18 @@ public class BroadcastOperationData implements OperationData {
         dest.writeParcelable(data, 0);
     }
 
-    public static final Parcelable.Creator<BroadcastOperationData> CREATOR
-            = new Parcelable.Creator<BroadcastOperationData>() {
-        public BroadcastOperationData createFromParcel(Parcel in) {
-            return new BroadcastOperationData(in);
+    public static final Parcelable.Creator<IntentOperationData> CREATOR
+            = new Parcelable.Creator<IntentOperationData>() {
+        public IntentOperationData createFromParcel(Parcel in) {
+            return new IntentOperationData(in);
         }
 
-        public BroadcastOperationData[] newArray(int size) {
-            return new BroadcastOperationData[size];
+        public IntentOperationData[] newArray(int size) {
+            return new IntentOperationData[size];
         }
     };
 
-    private BroadcastOperationData(Parcel in) {
+    private IntentOperationData(Parcel in) {
         data = in.readParcelable(IntentData.class.getClassLoader());
     }
 
@@ -231,6 +213,6 @@ public class BroadcastOperationData implements OperationData {
             }
             data.extras = new Extras(extras);
         }
-        return new BroadcastOperationData(intentData);
+        return new IntentOperationData(intentData);
     }
 }

--- a/app/src/main/java/ryey/easer/skills/operation/intent/IntentOperationDataFactory.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/IntentOperationDataFactory.java
@@ -17,7 +17,7 @@
  * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ryey.easer.skills.operation.broadcast;
+package ryey.easer.skills.operation.intent;
 
 import android.net.Uri;
 
@@ -32,17 +32,17 @@ import ryey.easer.plugin.PluginDataFormat;
 import ryey.easer.skills.operation.ExtraItem;
 import ryey.easer.skills.operation.Extras;
 
-class BroadcastOperationDataFactory implements OperationDataFactory<BroadcastOperationData> {
+class IntentOperationDataFactory implements OperationDataFactory<IntentOperationData> {
     @NonNull
     @Override
-    public Class<BroadcastOperationData> dataClass() {
-        return BroadcastOperationData.class;
+    public Class<IntentOperationData> dataClass() {
+        return IntentOperationData.class;
     }
 
     @ValidData
     @NonNull
     @Override
-    public BroadcastOperationData dummyData() {
+    public IntentOperationData dummyData() {
         IntentData intentData = new IntentData();
         intentData.action = "testAction";
         intentData.category = new ArrayList<>();
@@ -53,13 +53,13 @@ class BroadcastOperationDataFactory implements OperationDataFactory<BroadcastOpe
         ExtraItem extraItem = new ExtraItem("extra_key1", "extra_value1", "string");
         extras.add(extraItem);
         intentData.extras = new Extras(extras);
-        return new BroadcastOperationData(intentData);
+        return new IntentOperationData(intentData);
     }
 
     @ValidData
     @NonNull
     @Override
-    public BroadcastOperationData parse(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
-        return new BroadcastOperationData(data, format, version);
+    public IntentOperationData parse(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        return new IntentOperationData(data, format, version);
     }
 }

--- a/app/src/main/java/ryey/easer/skills/operation/intent/IntentOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/IntentOperationSkill.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016 - 2019 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.intent;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import ryey.easer.commons.local_skill.SkillView;
+import ryey.easer.commons.local_skill.operationskill.OperationDataFactory;
+import ryey.easer.commons.local_skill.operationskill.OperationSkill;
+import ryey.easer.commons.local_skill.operationskill.PrivilegeUsage;
+import ryey.easer.plugin.operation.Category;
+
+
+public abstract class IntentOperationSkill implements OperationSkill<IntentOperationData> {
+
+
+
+    @Override
+    public boolean isCompatible(@NonNull final Context context) {
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public PrivilegeUsage privilege() {
+        return PrivilegeUsage.no_root;
+    }
+
+    @Override
+    public int maxExistence() {
+        return 0;
+    }
+
+    @NonNull
+    @Override
+    public Category category() {
+        return Category.android;
+    }
+
+    @Nullable
+    @Override
+    public Boolean checkPermissions(@NonNull Context context) {
+        return null;
+    }
+
+    @Override
+    public void requestPermissions(@NonNull Activity activity, int requestCode) {
+
+    }
+
+    @NonNull
+    @Override
+    public OperationDataFactory<IntentOperationData> dataFactory() {
+        return new IntentOperationDataFactory();
+
+    }
+
+    @NonNull
+    @Override
+    public SkillView<IntentOperationData> view() {
+        return new IntentSkillViewFragment();
+    }
+
+
+}

--- a/app/src/main/java/ryey/easer/skills/operation/intent/IntentSkillViewFragment.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/IntentSkillViewFragment.java
@@ -17,7 +17,7 @@
  * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ryey.easer.skills.operation.broadcast;
+package ryey.easer.skills.operation.intent;
 
 import android.net.Uri;
 import android.os.Bundle;
@@ -36,7 +36,7 @@ import ryey.easer.commons.local_skill.ValidData;
 import ryey.easer.skills.SkillViewFragment;
 import ryey.easer.skills.operation.EditExtraFragment;
 
-public class BroadcastSkillViewFragment extends SkillViewFragment<BroadcastOperationData> {
+public class IntentSkillViewFragment extends SkillViewFragment<IntentOperationData> {
     private EditText m_text_action;
     private EditText m_text_category;
     private EditText m_text_type;
@@ -57,7 +57,7 @@ public class BroadcastSkillViewFragment extends SkillViewFragment<BroadcastOpera
     }
 
     @Override
-    protected void _fill(@ValidData @NonNull BroadcastOperationData data) {
+    protected void _fill(@ValidData @NonNull IntentOperationData data) {
         IntentData rdata = data.data;
         m_text_action.setText(rdata.action);
         m_text_category.setText(Utils.StringCollectionToString(rdata.category, false));
@@ -70,14 +70,14 @@ public class BroadcastSkillViewFragment extends SkillViewFragment<BroadcastOpera
     @ValidData
     @NonNull
     @Override
-    public BroadcastOperationData getData() throws InvalidDataInputException {
+    public IntentOperationData getData() throws InvalidDataInputException {
         IntentData data = new IntentData();
         data.action = m_text_action.getText().toString();
         data.category = Utils.stringToStringList(m_text_category.getText().toString());
         data.type = m_text_type.getText().toString();
         data.data = Uri.parse(m_text_data.getText().toString());
         data.extras = editExtraFragment.getExtras();
-        BroadcastOperationData broadcastOperationData = new BroadcastOperationData(data);
+        IntentOperationData broadcastOperationData = new IntentOperationData(data);
         return broadcastOperationData;
     }
 

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/ActivityLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/ActivityLoader.java
@@ -1,0 +1,22 @@
+package ryey.easer.skills.operation.intent.operations;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.skills.operation.intent.IntentLoader;
+import ryey.easer.skills.operation.intent.IntentOperationData;
+
+public class ActivityLoader extends IntentLoader<IntentOperationData> {
+
+    public ActivityLoader(@NonNull Context context) {
+        super(context);
+    }
+
+    @Override
+    public void _load(@NonNull IntentOperationData data, @NonNull OnResultCallback callback) {
+
+        context.startActivity(this.getIntent(data));
+        callback.onResult(true);
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/ActivityOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/ActivityOperationSkill.java
@@ -1,0 +1,30 @@
+package ryey.easer.skills.operation.intent.operations;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.R;
+import ryey.easer.skills.operation.OperationLoader;
+import ryey.easer.skills.operation.intent.IntentOperationData;
+import ryey.easer.skills.operation.intent.IntentOperationSkill;
+
+public class ActivityOperationSkill extends IntentOperationSkill {
+    @NonNull
+    @Override
+    public String id() {
+        return "start_activity";
+    }
+
+    @Override
+    public int name() {
+        return R.string.operation_start_activity;
+    }
+
+
+    @NonNull
+    @Override
+    public OperationLoader<IntentOperationData> loader(@NonNull Context context) {
+        return new ActivityLoader(context);
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/ActivityOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/ActivityOperationSkill.java
@@ -33,7 +33,10 @@ public class ActivityOperationSkill extends IntentOperationSkill {
     @NonNull
     @Override
     public SkillView<IntentOperationData> view() {
-        return new IntentSkillViewFragment() {
-        };
+        return new DummyIntentSkillViewFragment();
+    }
+
+    public static class DummyIntentSkillViewFragment extends IntentSkillViewFragment {
+
     }
 }

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastLoader.java
@@ -17,17 +17,13 @@
  * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ryey.easer.skills.operation.broadcast;
+package ryey.easer.skills.operation.intent.operations;
 
 import android.content.Context;
-import android.content.Intent;
 
 import androidx.annotation.NonNull;
 
-import ryey.easer.Utils;
 import ryey.easer.commons.local_skill.ValidData;
-import ryey.easer.skills.operation.OperationLoader;
-import ryey.easer.skills.operation.intent.IntentData;
 import ryey.easer.skills.operation.intent.IntentLoader;
 import ryey.easer.skills.operation.intent.IntentOperationData;
 

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastOperationSkill.java
@@ -5,9 +5,11 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import ryey.easer.R;
+import ryey.easer.commons.local_skill.SkillView;
 import ryey.easer.skills.operation.OperationLoader;
 import ryey.easer.skills.operation.intent.IntentOperationData;
 import ryey.easer.skills.operation.intent.IntentOperationSkill;
+import ryey.easer.skills.operation.intent.IntentSkillViewFragment;
 
 public class BroadcastOperationSkill extends IntentOperationSkill {
     @NonNull
@@ -26,5 +28,11 @@ public class BroadcastOperationSkill extends IntentOperationSkill {
     @Override
     public OperationLoader<IntentOperationData> loader(@NonNull Context context) {
         return new BroadcastLoader(context);
+    }
+
+    @NonNull
+    @Override
+    public SkillView<IntentOperationData> view() {
+        return new IntentSkillViewFragment(){};
     }
 }

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastOperationSkill.java
@@ -33,6 +33,11 @@ public class BroadcastOperationSkill extends IntentOperationSkill {
     @NonNull
     @Override
     public SkillView<IntentOperationData> view() {
-        return new IntentSkillViewFragment(){};
+        return new DummyIntentSkillViewFragment();
+    }
+
+    public static class DummyIntentSkillViewFragment extends IntentSkillViewFragment
+    {
+
     }
 }

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/BroadcastOperationSkill.java
@@ -1,4 +1,4 @@
-package ryey.easer.skills.operation.broadcast;
+package ryey.easer.skills.operation.intent.operations;
 
 import android.content.Context;
 

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/ServiceLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/ServiceLoader.java
@@ -1,0 +1,20 @@
+package ryey.easer.skills.operation.intent.operations;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.skills.operation.intent.IntentLoader;
+import ryey.easer.skills.operation.intent.IntentOperationData;
+
+public class ServiceLoader extends IntentLoader<IntentOperationData> {
+    public ServiceLoader(@NonNull Context context) {
+        super(context);
+    }
+
+    @Override
+    public void _load(@NonNull IntentOperationData data, @NonNull OnResultCallback callback) {
+        context.startService(this.getIntent(data));
+        callback.onResult(true);
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/ServiceOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/ServiceOperationSkill.java
@@ -33,6 +33,11 @@ public class ServiceOperationSkill extends IntentOperationSkill {
     @NonNull
     @Override
     public SkillView<IntentOperationData> view() {
-        return new IntentSkillViewFragment(){};
+        return new DummyIntentSkillViewFragment();
+    }
+
+    public static class DummyIntentSkillViewFragment extends IntentSkillViewFragment
+    {
+
     }
 }

--- a/app/src/main/java/ryey/easer/skills/operation/intent/operations/ServiceOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/intent/operations/ServiceOperationSkill.java
@@ -11,29 +11,28 @@ import ryey.easer.skills.operation.intent.IntentOperationData;
 import ryey.easer.skills.operation.intent.IntentOperationSkill;
 import ryey.easer.skills.operation.intent.IntentSkillViewFragment;
 
-public class ActivityOperationSkill extends IntentOperationSkill {
+public class ServiceOperationSkill extends IntentOperationSkill {
     @NonNull
     @Override
     public String id() {
-        return "start_activity";
+        return "start_service";
     }
 
     @Override
     public int name() {
-        return R.string.operation_start_activity;
+        return R.string.operation_start_service;
     }
 
 
     @NonNull
     @Override
     public OperationLoader<IntentOperationData> loader(@NonNull Context context) {
-        return new ActivityLoader(context);
+        return new ServiceLoader(context);
     }
 
     @NonNull
     @Override
     public SkillView<IntentOperationData> view() {
-        return new IntentSkillViewFragment() {
-        };
+        return new IntentSkillViewFragment(){};
     }
 }

--- a/app/src/main/res/values/plugins.xml
+++ b/app/src/main/res/values/plugins.xml
@@ -108,6 +108,7 @@
 
     <string name="operation_broadcast">Send Broadcast</string>
     <string name="operation_start_activity">Start Activity</string>
+    <string name="operation_start_service">Start Service</string>
     <string name="obroadcast_l_action">Action:</string>
     <string name="obroadcast_l_category">Category:</string>
     <string name="obroadcast_l_type">Type:</string>

--- a/app/src/main/res/values/plugins.xml
+++ b/app/src/main/res/values/plugins.xml
@@ -107,6 +107,7 @@
     <string name="operation_brightness_desc_autobrightness">Auto brightness</string>
 
     <string name="operation_broadcast">Send Broadcast</string>
+    <string name="operation_start_activity">Start Activity</string>
     <string name="obroadcast_l_action">Action:</string>
     <string name="obroadcast_l_category">Category:</string>
     <string name="obroadcast_l_type">Type:</string>

--- a/app/src/test/java/ryey/easer/skills/PluginDataTest.java
+++ b/app/src/test/java/ryey/easer/skills/PluginDataTest.java
@@ -26,7 +26,7 @@ import ryey.easer.plugin.PluginDataFormat;
 import ryey.easer.commons.local_skill.DataFactory;
 import ryey.easer.commons.local_skill.Skill;
 import ryey.easer.commons.local_skill.StorageData;
-import ryey.easer.skills.operation.broadcast.BroadcastOperationSkill;
+import ryey.easer.skills.operation.intent.IntentOperationSkill;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,7 +35,7 @@ public class PluginDataTest {
     @Test
     public void testPluginData() throws Exception {
         for (Skill plugin : LocalSkillRegistry.getInstance().all().getAllSkills()) {
-            if (plugin instanceof BroadcastOperationSkill)
+            if (plugin instanceof IntentOperationSkill)
                 continue;
             DataFactory factory = plugin.dataFactory();
             StorageData dummyData = factory.dummyData();


### PR DESCRIPTION
Hi,
this PR creates 2 new operations for starting an Activity and starting a Service.
For that, I moved some code from the Broadcast-classes to new abstract upper classes Intent[Data,Loader,...].
Note:
Both start only implicit intents (no package name, just action, category, etc.)