### PR TITLE
Add profile to connect to bluetooth device

### DIFF
--- a/app/src/androidTest/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationDataTest.java
+++ b/app/src/androidTest/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationDataTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.bluetooth_connect;
+
+import android.os.Parcel;
+
+import org.junit.Test;
+
+import ryey.easer.skills.TestHelper;
+
+import static org.junit.Assert.assertEquals;
+
+public class BluetoothConnectOperationDataTest {
+
+    @Test
+    public void testParcel() {
+        BluetoothConnectOperationData dummyData = new BluetoothConnectOperationDataFactory().dummyData();
+        Parcel parcel = TestHelper.writeToParcel(dummyData);
+        BluetoothConnectOperationData parceledData = BluetoothConnectOperationData.CREATOR.createFromParcel(parcel);
+        assertEquals(dummyData, parceledData);
+    }
+
+}

--- a/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
+++ b/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
@@ -56,6 +56,7 @@ import ryey.easer.skills.event.widget.WidgetEventSkill;
 import ryey.easer.skills.operation.airplane_mode.AirplaneModeOperationSkill;
 import ryey.easer.skills.operation.alarm.AlarmOperationSkill;
 import ryey.easer.skills.operation.bluetooth.BluetoothOperationSkill;
+import ryey.easer.skills.operation.bluetooth_connect.BluetoothConnectOperationSkill;
 import ryey.easer.skills.operation.brightness.BrightnessOperationSkill;
 import ryey.easer.skills.operation.broadcast.BroadcastOperationSkill;
 import ryey.easer.skills.operation.cellular.CellularOperationSkill;
@@ -150,6 +151,7 @@ final public class LocalSkillRegistry {
         operation().registerSkill(AirplaneModeOperationSkill.class);
         operation().registerSkill(AlarmOperationSkill.class);
         operation().registerSkill(BluetoothOperationSkill.class);
+        operation().registerSkill(BluetoothConnectOperationSkill.class);
         operation().registerSkill(BrightnessOperationSkill.class);
         operation().registerSkill(BroadcastOperationSkill.class);
         operation().registerSkill(CellularOperationSkill.class);

--- a/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectLoader.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2016 - 2018, 2020 Rui Zhao <renyuneyun@gmail.com> and Daniel Landau
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.bluetooth_connect;
+
+import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothA2dp;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattServer;
+import android.bluetooth.BluetoothHeadset;
+import android.bluetooth.BluetoothHearingAid;
+import android.bluetooth.BluetoothHidDevice;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.BluetoothProfile;
+import android.content.Context;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+import com.orhanobut.logger.Logger;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import ryey.easer.commons.local_skill.ValidData;
+import ryey.easer.skills.operation.OperationLoader;
+
+public class BluetoothConnectLoader extends OperationLoader<BluetoothConnectOperationData> implements BluetoothRequester.Callback {
+    private BluetoothAdapter mAdapter;
+    private String mAddress;
+    private String mService;
+    private OnResultCallback mCallback;
+
+    BluetoothConnectLoader(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void _load(@ValidData @NonNull BluetoothConnectOperationData data, @NonNull OnResultCallback callback) {
+        mAddress = data.address;
+        mService = data.service;
+        mCallback = callback;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            BluetoothManager bluetoothManager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+            if (bluetoothManager != null) {
+                mAdapter = bluetoothManager.getAdapter();
+                if (mAdapter == null) {
+                    Logger.w("no bluetoothAdapter");
+                    callback.onResult(false);
+                    return;
+                }
+                new BluetoothRequester(this).request(context, mAdapter, getBluetoothProfile());
+            } else {
+                Logger.wtf("Couldn't get system bluetooth manager");
+                callback.onResult(false);
+            }
+        } else {
+            Logger.wtf("System version lower than min requirement");
+            callback.onResult(false);
+        }
+    }
+
+    private int getBluetoothProfile() {
+        switch (mService) {
+            case BluetoothConnectOperationData.A2DP:
+                return BluetoothProfile.A2DP;
+            case BluetoothConnectOperationData.HEADSET:
+                return BluetoothProfile.HEADSET;
+            case BluetoothConnectOperationData.HID_DEVICE:
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                    return BluetoothProfile.HID_DEVICE;
+                break;
+            case BluetoothConnectOperationData.HEARING_AID:
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                    return BluetoothProfile.HEARING_AID;
+                break;
+            case BluetoothConnectOperationData.GATT:
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                    return BluetoothProfile.GATT;
+                break;
+            case BluetoothConnectOperationData.GATT_SERVER:
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                    return BluetoothProfile.GATT_SERVER;
+                break;
+        }
+        return -1;
+    }
+
+    // From https://github.com/kcoppock/bluetooth-a2dp with modifications
+    @Override
+    public void onProxyReceived(BluetoothProfile proxy) {
+        Method connect = getConnectMethod();
+        BluetoothDevice device = findBondedDeviceByAddress(mAdapter, mAddress);
+        if (connect == null || device == null) {
+            return;
+        }
+
+        try {
+            connect.setAccessible(true);
+            connect.invoke(proxy, device);
+            mCallback.onResult(true);
+        } catch (InvocationTargetException ignored) {
+        } catch (IllegalAccessException ignored) {
+        }
+    }
+
+
+    @SuppressLint("PrivateApi")
+    private Method getConnectMethod () {
+        try {
+            switch (mService) {
+                case BluetoothConnectOperationData.A2DP:
+                    return BluetoothA2dp.class.getDeclaredMethod("connect", BluetoothDevice.class);
+                case BluetoothConnectOperationData.HEADSET:
+                    return BluetoothHeadset.class.getDeclaredMethod("connect", BluetoothDevice.class);
+                case BluetoothConnectOperationData.HID_DEVICE:
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                        return BluetoothHidDevice.class.getDeclaredMethod("connect", BluetoothDevice.class);
+                case BluetoothConnectOperationData.HEARING_AID:
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                    return BluetoothHearingAid.class.getDeclaredMethod("connect", BluetoothDevice.class);
+                case BluetoothConnectOperationData.GATT:
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                        return BluetoothGatt.class.getDeclaredMethod("connect", BluetoothDevice.class);
+                case BluetoothConnectOperationData.GATT_SERVER:
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                        return BluetoothGattServer.class.getDeclaredMethod("connect", BluetoothDevice.class);
+            }
+            return null;
+        } catch (NoSuchMethodException ex) {
+            return null;
+        }
+    }
+
+    private static BluetoothDevice findBondedDeviceByAddress (BluetoothAdapter adapter, String address) {
+        for (BluetoothDevice device : getBondedDevices(adapter)) {
+            if (address.matches(device.getAddress())) {
+                return device;
+            }
+        }
+        return null;
+    }
+
+    private static Set<BluetoothDevice> getBondedDevices (BluetoothAdapter adapter) {
+        Set<BluetoothDevice> results = adapter.getBondedDevices();
+        if (results == null) {
+            results = new HashSet<BluetoothDevice>();
+        }
+        return results;
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationData.java
+++ b/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationData.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2016 - 2018, 2020 Rui Zhao <renyuneyun@gmail.com> and Daniel Landau
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.bluetooth_connect;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Set;
+
+import ryey.easer.Utils;
+import ryey.easer.commons.local_skill.IllegalStorageDataException;
+import ryey.easer.commons.local_skill.dynamics.SolidDynamicsAssignment;
+import ryey.easer.commons.local_skill.operationskill.OperationData;
+import ryey.easer.plugin.PluginDataFormat;
+
+public class BluetoothConnectOperationData implements OperationData {
+
+    private static final String K_ADDRESS = "address";
+    private static final String K_SERVICE = "service";
+
+    public static final String A2DP = "A2DP";
+    public static final String HID_DEVICE = "HID Device";
+    public static final String HEADSET = "Headset";
+    public static final String HEARING_AID = "Hearing Aid";
+    public static final String GATT = "Gatt";
+    public static final String GATT_SERVER = "Gatt Server";
+
+    String address;
+    String service;
+
+    public BluetoothConnectOperationData(String address, String service) {
+        this.address = address;
+        this.service = service;
+    }
+
+    BluetoothConnectOperationData(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        parse(data, format, version);
+    }
+
+    public void parse(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        switch (format) {
+            default:
+                try {
+                    JSONObject jsonObject = new JSONObject(data);
+                    address = jsonObject.getString(K_ADDRESS);
+                    service = jsonObject.getString(K_SERVICE);
+                } catch (JSONException e) {
+                    throw new IllegalStorageDataException(e);
+                }
+        }
+    }
+    @NonNull
+    @Override
+    public String serialize(@NonNull PluginDataFormat format) {
+        String res;
+        switch (format) {
+            default:
+                JSONObject jsonObject = new JSONObject();
+                try {
+                    jsonObject.put(K_ADDRESS, address);
+                    jsonObject.put(K_SERVICE, service);
+                } catch (JSONException e) {
+                    throw new IllegalStateException(e);
+                }
+                res = jsonObject.toString();
+        }
+        return res;
+    }
+
+    @SuppressWarnings({"SimplifiableIfStatement", "RedundantIfStatement"})
+    @Override
+    public boolean isValid() {
+        if (address == null)
+            return false;
+        if (service == null)
+            return false;
+        return true;
+    }
+
+    @SuppressWarnings({"SimplifiableIfStatement", "RedundantIfStatement"})
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        if (!(obj instanceof BluetoothConnectOperationData))
+            return false;
+        if (!((BluetoothConnectOperationData) obj).isValid())
+            return false;
+        if (!Utils.nullableEqual(address,
+                ((BluetoothConnectOperationData) obj).address))
+            return false;
+        if (!Utils.nullableEqual(service,
+                ((BluetoothConnectOperationData) obj).service))
+            return false;
+        return true;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(address);
+        parcel.writeString(service);
+    }
+
+    private BluetoothConnectOperationData(Parcel in) {
+        address = in.readString();
+        service = in.readString();
+    }
+
+    public static final Creator<BluetoothConnectOperationData> CREATOR
+            = new Creator<BluetoothConnectOperationData>() {
+        public BluetoothConnectOperationData createFromParcel(Parcel in) {
+            return new BluetoothConnectOperationData(in);
+        }
+
+        public BluetoothConnectOperationData[] newArray(int size) {
+            return new BluetoothConnectOperationData[size];
+        }
+    };
+
+    @Nullable
+    @Override
+    public Set<String> placeholders() {
+        Set<String> placeholders = Utils.extractPlaceholder(address);
+        placeholders.addAll(Utils.extractPlaceholder(service));
+        return placeholders;
+    }
+
+    @NonNull
+    @Override
+    public OperationData applyDynamics(SolidDynamicsAssignment dynamicsAssignment) {
+        String new_address = Utils.applyDynamics(address, dynamicsAssignment);
+        String new_service = Utils.applyDynamics(service, dynamicsAssignment);
+        return new BluetoothConnectOperationData(new_address, new_service);
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationDataFactory.java
+++ b/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationDataFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016 - 2018, 2020 Rui Zhao <renyuneyun@gmail.com> and Daniel Landau
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.bluetooth_connect;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.commons.local_skill.IllegalStorageDataException;
+import ryey.easer.commons.local_skill.ValidData;
+import ryey.easer.commons.local_skill.operationskill.OperationDataFactory;
+import ryey.easer.plugin.PluginDataFormat;
+
+class BluetoothConnectOperationDataFactory implements OperationDataFactory<BluetoothConnectOperationData> {
+    @NonNull
+    @Override
+    public Class<BluetoothConnectOperationData> dataClass() {
+        return BluetoothConnectOperationData.class;
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public BluetoothConnectOperationData dummyData() {
+        return new BluetoothConnectOperationData("00:11:22:33:FF:EE",
+                BluetoothConnectOperationData.A2DP);
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public BluetoothConnectOperationData parse(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        return new BluetoothConnectOperationData(data, format, version);
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectOperationSkill.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016 - 2018, 2020 Rui Zhao <renyuneyun@gmail.com> and Daniel Landau
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.bluetooth_connect;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.R;
+import ryey.easer.plugin.operation.Category;
+import ryey.easer.skills.SkillViewFragment;
+import ryey.easer.commons.local_skill.operationskill.OperationDataFactory;
+import ryey.easer.skills.operation.OperationLoader;
+import ryey.easer.commons.local_skill.operationskill.OperationSkill;
+import ryey.easer.commons.local_skill.operationskill.PrivilegeUsage;
+
+public class BluetoothConnectOperationSkill implements OperationSkill<BluetoothConnectOperationData> {
+
+    @NonNull
+    @Override
+    public String id() {
+        return "bluetooth_connect";
+    }
+
+    @Override
+    public int name() {
+        return R.string.operation_bluetooth_connect;
+    }
+
+    @Override
+    public boolean isCompatible(@NonNull final Context context) {
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public PrivilegeUsage privilege() {
+        return PrivilegeUsage.no_root;
+    }
+
+    @Override
+    public int maxExistence() {
+        return 0;
+    }
+
+    @NonNull
+    @Override
+    public Category category() {
+        return Category.system_config;
+    }
+
+    @Override
+    public Boolean checkPermissions(@NonNull Context context) {
+        return true;
+    }
+
+    @Override
+    public void requestPermissions(@NonNull Activity activity, int requestCode) {
+    }
+
+    @NonNull
+    @Override
+    public OperationDataFactory<BluetoothConnectOperationData> dataFactory() {
+        return new BluetoothConnectOperationDataFactory();
+
+    }
+
+    @NonNull
+    @Override
+    public SkillViewFragment<BluetoothConnectOperationData> view() {
+        return new BluetoothConnectSkillViewFragment();
+    }
+
+    @NonNull
+    @Override
+    public OperationLoader<BluetoothConnectOperationData> loader(@NonNull Context context) {
+        return new BluetoothConnectLoader(context);
+    }
+
+}

--- a/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectSkillViewFragment.java
+++ b/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothConnectSkillViewFragment.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016 - 2018, 2020 Rui Zhao <renyuneyun@gmail.com> and Daniel Landau
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.bluetooth_connect;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Spinner;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import ryey.easer.R;
+import ryey.easer.commons.local_skill.InvalidDataInputException;
+import ryey.easer.commons.ui.DataSelectSpinnerWrapper;
+import ryey.easer.skills.SkillViewFragment;
+import ryey.easer.commons.local_skill.ValidData;
+
+public class BluetoothConnectSkillViewFragment extends SkillViewFragment<BluetoothConnectOperationData> {
+    private EditText editText;
+    private DataSelectSpinnerWrapper profileSpinner;
+
+    @NonNull
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.skill_operation__bluetooth_connect, container, false);
+        editText = view.findViewById(R.id.editText_bluetooth_address);
+        profileSpinner = new DataSelectSpinnerWrapper(Objects.requireNonNull(getContext()), (Spinner) view.findViewById(R.id.bluetooth_profile_spinner));
+
+        List<String> options = new ArrayList<>();
+        options.add(BluetoothConnectOperationData.A2DP);
+        options.add(BluetoothConnectOperationData.HEADSET);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            options.add(BluetoothConnectOperationData.HID_DEVICE);
+            options.add(BluetoothConnectOperationData.GATT);
+            options.add(BluetoothConnectOperationData.GATT_SERVER);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            options.add(BluetoothConnectOperationData.HEARING_AID);
+        }
+
+        profileSpinner.beginInit().setAllowEmpty(false).fillData(options).finalizeInit();
+        return view;
+    }
+
+    @Override
+    protected void _fill(@ValidData @NonNull BluetoothConnectOperationData data) {
+        editText.setText(data.address);
+        profileSpinner.setSelection(data.service);
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public BluetoothConnectOperationData getData() throws InvalidDataInputException {
+        return new BluetoothConnectOperationData(editText.getText().toString(), profileSpinner.getSelection());
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothRequester.java
+++ b/app/src/main/java/ryey/easer/skills/operation/bluetooth_connect/BluetoothRequester.java
@@ -1,0 +1,65 @@
+package ryey.easer.skills.operation.bluetooth_connect;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothProfile;
+import android.content.Context;
+
+// From https://github.com/kcoppock/bluetooth-a2dp
+
+/**
+ *
+ * Copyright 2013 Kevin Coppock, 2020 Daniel Landau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Sends an asynchronous request to the BluetoothAdapter for an instance of a
+ * BluetoothA2dp proxy.
+ */
+public class BluetoothRequester implements BluetoothProfile.ServiceListener {
+    private Callback mCallback;
+
+    /**
+     * Creates a new instance of an A2DP Proxy requester with the
+     * callback that should receive the proxy once it is acquired
+     * @param callback the callback that should receive the proxy
+     */
+    public BluetoothRequester(Callback callback) {
+        mCallback = callback;
+    }
+
+    /**
+     * Start an asynchronous request to acquire the A2DP proxy. The callback
+     * will be notified when the proxy is acquired
+     * @param c the context used to obtain the proxy
+     * @param adapter the BluetoothAdapter that should receive the request for proxy
+     */
+    public void request (Context c, BluetoothAdapter adapter, int profile) {
+        adapter.getProfileProxy(c, this, profile);
+    }
+
+    @Override
+    public void onServiceConnected(int i, BluetoothProfile bluetoothProfile) {
+        if (mCallback != null) {
+            mCallback.onProxyReceived(bluetoothProfile);
+        }
+    }
+
+    @Override
+    public void onServiceDisconnected(int i) {
+        //It's a one-off connection attempt; we don't care about the disconnection event.
+    }
+
+    public static interface Callback {
+        public void onProxyReceived(BluetoothProfile proxy);
+    }
+}

--- a/app/src/main/res/layout/skill_operation__bluetooth_connect.xml
+++ b/app/src/main/res/layout/skill_operation__bluetooth_connect.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline7"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="20dp" />
+
+    <TextView
+        android:id="@+id/textView24"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/mac_address"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginLeft="8dp" />
+
+    <EditText
+        android:id="@+id/editText_bluetooth_address"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:ems="10"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline7"
+        app:layout_constraintTop_toBottomOf="@+id/textView24" />
+
+    <TextView
+        android:id="@+id/textView25"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/bluetooth_device_profile"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editText_bluetooth_address"
+        android:layout_marginLeft="8dp" />
+
+    <Spinner
+        android:id="@+id/bluetooth_profile_spinner"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:ems="10"
+        android:inputType="textMultiLine"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline7"
+        app:layout_constraintTop_toBottomOf="@+id/textView25" />
+
+    <TextView
+        android:id="@+id/textView26"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/bluetooth_maybe_not_supported"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/bluetooth_profile_spinner"
+        android:layout_marginLeft="8dp" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,8 @@
     <string name="category_operation_easer">@string/easer</string>
     <string name="category_operation_misc">Misc</string>
     <string name="category_operation_unknown">Unknown</string>
+    <string name="operation_bluetooth_connect">Connect to Bluetooth device</string>
+    <string name="mac_address">MAC Address (00:11:22:33:FF:EE)</string>
+    <string name="bluetooth_device_profile">Bluetooth Device Profile</string>
+    <string name="bluetooth_maybe_not_supported">This Easer profile uses a method that is not officially supported by Android. It might not work on all devices.</string>
 </resources>


### PR DESCRIPTION
This has been tested with the A2DP and Headset profiles on two different
bluetooth devices that I had at hand, but I didn't have easy access to the other
device profiles. They should work the same though.

There doesn't seem to be an officially supported method of automating connecting
to already paired devices, but this method using reflection seems to be quite
stable, as the code I imported (Apache 2.0 License) is from 2013, but still
works (tested with Android Pie).