### PR TITLE
update polish translation

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -53,7 +53,7 @@
     <string name="alert_update_storage_data_title">Znaleziono starą wersję danych</string>
     <string name="welcome_message_privacy">Prywatność jest ważna!
 \n 
-\nEaser to <a href="https://en.wikipedia.org/wiki/Free_software"> darmowe oprogramowanie </a> (oprogramowanie typu open source), zapewniające wszystkim korzystanie, badanie, zmianę i udostępnianie.
+\nEaser to <a href="https://pl.m.wikipedia.org/wiki/Wolne_oprogramowanie"> wolne oprogramowanie </a> (oprogramowanie typu open source), zapewniające wszystkim korzystanie, badanie, zmianę i udostępnianie.
 \n 
 \nJesteś właścicielem każdego elementu swoich danych. Wszystko żyje na twoim urządzeniu, w tym logi.</string>
     <string name="title_welcome_message_privacy">Prywatność!</string>


### PR DESCRIPTION
1. Darmowe means free as in beer and wolne free as in speech.
2. changed wikipedia to Polish and link to mobile because most of users will click this on mobile