### PR TITLE
Add Wireguard operation

### DIFF
--- a/app/src/androidTest/java/ryey/easer/skills/operation/wireguard/WireguardOperationDataTest.java
+++ b/app/src/androidTest/java/ryey/easer/skills/operation/wireguard/WireguardOperationDataTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.wireguard;
+
+import android.os.Parcel;
+
+import org.junit.Test;
+
+import ryey.easer.skills.TestHelper;
+
+import static org.junit.Assert.assertEquals;
+
+public class WireguardOperationDataTest {
+
+    @Test
+    public void testParcel() {
+        WireguardOperationData dummyData = new WireguardOperationDataFactory().dummyData();
+        Parcel parcel = TestHelper.writeToParcel(dummyData);
+        WireguardOperationData parceledData = WireguardOperationData.CREATOR.createFromParcel(parcel);
+        assertEquals(dummyData, parceledData);
+    }
+
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         tools:ignore="ProtectedPermissions" /> <!-- This is for some operations which do not guarantee to work -->
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+    <uses-permission android:name="com.wireguard.android.permission.CONTROL_TUNNELS"/>
 
     <application
         android:name=".EaserApplication"
@@ -232,4 +233,7 @@
 
     </application>
 
+    <queries>
+        <package android:name="com.wireguard.android" />
+    </queries>
 </manifest>

--- a/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
+++ b/app/src/main/java/ryey/easer/skills/LocalSkillRegistry.java
@@ -79,6 +79,7 @@ import ryey.easer.skills.operation.synchronization.SynchronizationOperationSkill
 import ryey.easer.skills.operation.ui_mode.UiModeOperationSkill;
 import ryey.easer.skills.operation.volume.VolumeOperationSkill;
 import ryey.easer.skills.operation.wifi.WifiOperationSkill;
+import ryey.easer.skills.operation.wireguard.WireguardOperationSkill;
 import ryey.easer.skills.usource.battery_level.BatteryLevelUSourceSkill;
 import ryey.easer.skills.usource.bluetooth_device.BTDeviceUSourceSkill;
 import ryey.easer.skills.usource.bluetooth_enabled.BluetoothEnabledUSourceSkill;
@@ -173,6 +174,7 @@ final public class LocalSkillRegistry {
         operation().registerSkill(UiModeOperationSkill.class);
         operation().registerSkill(VolumeOperationSkill.class);
         operation().registerSkill(WifiOperationSkill.class);
+        operation().registerSkill(WireguardOperationSkill.class);
         operation().registerSkill(ActivityOperationSkill.class);
         operation().registerSkill(BroadcastOperationSkill.class);
         operation().registerSkill(ServiceOperationSkill.class);

--- a/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardLoader.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.wireguard;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.skills.operation.OperationLoader;
+
+public class WireguardLoader extends OperationLoader<WireguardOperationData> {
+    static final String INTENT_STATE_UP = "com.wireguard.android.action.SET_TUNNEL_UP";
+    static final String INTENT_STATE_DOWN = "com.wireguard.android.action.SET_TUNNEL_DOWN";
+
+    static final String EXTRA_TUNNEL_NAME = "tunnel";
+
+    WireguardLoader(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void _load(@NonNull WireguardOperationData data, @NonNull OnResultCallback callback) {
+        Intent intent = new Intent(data.tunnel_state ? INTENT_STATE_UP : INTENT_STATE_DOWN);
+        intent.setPackage(WireguardOperationSkill.WIREGUARD_APP);
+        intent.putExtra(EXTRA_TUNNEL_NAME, data.tunnel_name);
+        context.sendBroadcast(intent);
+        callback.onResult(true);
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardOperationData.java
+++ b/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardOperationData.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.wireguard;
+
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Set;
+
+import ryey.easer.Utils;
+import ryey.easer.commons.local_skill.IllegalStorageDataException;
+import ryey.easer.commons.local_skill.dynamics.SolidDynamicsAssignment;
+import ryey.easer.commons.local_skill.operationskill.OperationData;
+import ryey.easer.plugin.PluginDataFormat;
+
+public class WireguardOperationData implements OperationData {
+    private static final String K_TUNNEL_NAME = "tunnel_name";
+    private static final String K_TUNNEL_STATE = "tunnel_state";
+
+    final String tunnel_name;
+    final Boolean tunnel_state;
+
+    WireguardOperationData(@NonNull String tunnel_name, @NonNull Boolean tunnel_state) {
+        this.tunnel_name = tunnel_name;
+        this.tunnel_state = tunnel_state;
+    }
+
+    WireguardOperationData(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        switch (format) {
+            default:
+                try {
+                    JSONObject jsonObject = new JSONObject(data);
+                    tunnel_name = jsonObject.getString(K_TUNNEL_NAME);
+                    tunnel_state = jsonObject.getBoolean(K_TUNNEL_STATE);
+                } catch (JSONException e) {
+                    throw new IllegalStorageDataException(e);
+                }
+        }
+    }
+
+    @NonNull
+    @Override
+    public String serialize(@NonNull PluginDataFormat format) {
+        String s = "";
+        switch (format) {
+            default:
+                try {
+                    JSONObject jsonObject = new JSONObject();
+                    jsonObject.put(K_TUNNEL_NAME, tunnel_name);
+                    jsonObject.put(K_TUNNEL_STATE, tunnel_state);
+                    s = jsonObject.toString();
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+        }
+        return s;
+    }
+
+    @Override
+    public boolean isValid() {
+        return !Utils.isBlank(tunnel_name) && tunnel_state != null;
+    }
+
+    @SuppressWarnings({"SimplifiableIfStatement", "RedundantIfStatement"})
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this)
+            return true;
+        if (!(obj instanceof WireguardOperationData))
+            return false;
+        if (!Utils.nullableEqual(tunnel_name, ((WireguardOperationData) obj).tunnel_name))
+            return false;
+        if (!Utils.nullableEqual(tunnel_state, ((WireguardOperationData) obj).tunnel_state))
+            return false;
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Set<String> placeholders() {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public OperationData applyDynamics(SolidDynamicsAssignment dynamicsAssignment) {
+        return this;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(tunnel_name);
+        dest.writeByte((byte) (tunnel_state ? 1 : 0));
+    }
+
+    public static final Creator<WireguardOperationData> CREATOR
+            = new Creator<WireguardOperationData>() {
+        public WireguardOperationData createFromParcel(Parcel in) {
+            return new WireguardOperationData(in);
+        }
+
+        public WireguardOperationData[] newArray(int size) {
+            return new WireguardOperationData[size];
+        }
+    };
+
+    private WireguardOperationData(Parcel in) {
+        tunnel_name = in.readString();
+        tunnel_state = in.readByte() != 0;
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardOperationDataFactory.java
+++ b/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardOperationDataFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.wireguard;
+
+import androidx.annotation.NonNull;
+
+import ryey.easer.commons.local_skill.IllegalStorageDataException;
+import ryey.easer.commons.local_skill.ValidData;
+import ryey.easer.commons.local_skill.operationskill.OperationDataFactory;
+import ryey.easer.plugin.PluginDataFormat;
+
+class WireguardOperationDataFactory implements OperationDataFactory<WireguardOperationData> {
+    @NonNull
+    @Override
+    public Class<WireguardOperationData> dataClass() {
+        return WireguardOperationData.class;
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public WireguardOperationData dummyData() {
+        return new WireguardOperationData("MyTunnel", true);
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public WireguardOperationData parse(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
+        return new WireguardOperationData(data, format, version);
+    }
+}

--- a/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardOperationSkill.java
+++ b/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardOperationSkill.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.wireguard;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.pm.PackageInfoCompat;
+
+import ryey.easer.R;
+import ryey.easer.plugin.operation.Category;
+import ryey.easer.skills.SkillUtils;
+import ryey.easer.skills.SkillViewFragment;
+import ryey.easer.commons.local_skill.operationskill.OperationDataFactory;
+import ryey.easer.skills.operation.OperationLoader;
+import ryey.easer.commons.local_skill.operationskill.OperationSkill;
+import ryey.easer.commons.local_skill.operationskill.PrivilegeUsage;
+
+public class WireguardOperationSkill implements OperationSkill<WireguardOperationData> {
+    static final String WIREGUARD_APP = "com.wireguard.android";
+    static final long WIREGUARD_APP_MINIMUM_VERSION = 466; // 0.0.20200322
+
+    static final class permission {
+        static final String CONTROL_TUNNELS = "com.wireguard.android.permission.CONTROL_TUNNELS";
+    }
+
+    @NonNull
+    @Override
+    public String id() {
+        return "wireguard";
+    }
+
+    @Override
+    public int name() {
+        return R.string.operation_wireguard;
+    }
+
+    @Override
+    public boolean isCompatible(@NonNull final Context context) {
+        try {
+            PackageInfo info = context.getPackageManager().getPackageInfo(WIREGUARD_APP, 0);
+            return PackageInfoCompat.getLongVersionCode(info) >= WIREGUARD_APP_MINIMUM_VERSION;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
+    }
+
+    @NonNull
+    @Override
+    public PrivilegeUsage privilege() {
+        return PrivilegeUsage.no_root;
+    }
+
+    @Override
+    public int maxExistence() {
+        return 0;
+    }
+
+    @NonNull
+    @Override
+    public Category category() {
+        return Category.misc;
+    }
+
+    @Override
+    public Boolean checkPermissions(@NonNull Context context) {
+        return SkillUtils.checkPermission(context, permission.CONTROL_TUNNELS);
+    }
+
+    @Override
+    public void requestPermissions(@NonNull Activity activity, int requestCode) {
+        if (!SkillUtils.checkPermission(activity, permission.CONTROL_TUNNELS)) {
+            SkillUtils.requestPermission(activity, requestCode, permission.CONTROL_TUNNELS);
+        }
+    }
+
+    @NonNull
+    @Override
+    public OperationDataFactory<WireguardOperationData> dataFactory() {
+        return new WireguardOperationDataFactory();
+    }
+
+    @NonNull
+    @Override
+    public SkillViewFragment<WireguardOperationData> view() {
+        return new WireguardSkillViewFragment();
+    }
+
+    @NonNull
+    @Override
+    public OperationLoader<WireguardOperationData> loader(@NonNull Context context) {
+        return new WireguardLoader(context);
+    }
+
+}

--- a/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardSkillViewFragment.java
+++ b/app/src/main/java/ryey/easer/skills/operation/wireguard/WireguardSkillViewFragment.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016 - 2018 Rui Zhao <renyuneyun@gmail.com>
+ *
+ * This file is part of Easer.
+ *
+ * Easer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Easer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Easer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ryey.easer.skills.operation.wireguard;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Spinner;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import ryey.easer.R;
+import ryey.easer.commons.local_skill.InvalidDataInputException;
+import ryey.easer.skills.SkillViewFragment;
+import ryey.easer.commons.local_skill.ValidData;
+
+public class WireguardSkillViewFragment extends SkillViewFragment<WireguardOperationData> {
+    private EditText et_tunnel_name;
+    private Spinner spinner_tunnel_state;
+
+    @NonNull
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.skill_operation__wireguard, container, false);
+        et_tunnel_name = view.findViewById(R.id.editText_tunnel_name);
+        spinner_tunnel_state = view.findViewById(R.id.spinner_tunnel_state);
+        return view;
+    }
+
+    @Override
+    protected void _fill(@ValidData @NonNull WireguardOperationData data) {
+        et_tunnel_name.setText(data.tunnel_name);
+        spinner_tunnel_state.setSelection(data.tunnel_state ? 0 : 1);
+    }
+
+    @ValidData
+    @NonNull
+    @Override
+    public WireguardOperationData getData() throws InvalidDataInputException {
+        return new WireguardOperationData(et_tunnel_name.getText().toString(), spinner_tunnel_state.getSelectedItemPosition() == 0);
+    }
+}

--- a/app/src/main/res/layout/skill_operation__wireguard.xml
+++ b/app/src/main/res/layout/skill_operation__wireguard.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <RadioGroup
+        android:id="@+id/radioGroup8"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:checkedButton="@+id/radioButton_setState"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <RadioButton
+            android:id="@+id/radioButton_setState"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/o_wireguard__set_tunnel_state" />
+    </RadioGroup>
+
+    <TextView
+        android:id="@+id/textView56"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/o_wireguard_tunnel_name"
+        app:layout_constraintBottom_toBottomOf="@+id/editText_tunnel_name"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/editText_tunnel_name" />
+
+    <EditText
+        android:id="@+id/editText_tunnel_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:ems="10"
+        android:hint="@string/o_wireguard_tunnel_name_hint"
+        android:inputType="none"
+        android:singleLine="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/textView56"
+        app:layout_constraintTop_toBottomOf="@+id/radioGroup8" />
+
+    <TextView
+        android:id="@+id/textView55"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:text="@string/o_wireguard_tunnel_state"
+        app:layout_constraintBottom_toBottomOf="@+id/spinner_tunnel_state"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/spinner_tunnel_state" />
+
+    <Spinner
+        android:id="@+id/spinner_tunnel_state"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:entries="@array/o_wireguard_tunnel_states"
+        android:spinnerMode="dropdown"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/textView55"
+        app:layout_constraintTop_toBottomOf="@+id/editText_tunnel_name" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/plugins.xml
+++ b/app/src/main/res/values/plugins.xml
@@ -212,6 +212,16 @@
 
     <string name="operation_wifi">Wi-Fi</string>
 
+    <string name="operation_wireguard">Wireguard</string>
+    <string name="o_wireguard__set_tunnel_state">Set Tunnel State</string>
+    <string name="o_wireguard_tunnel_name">Tunnel Name</string>
+    <string name="o_wireguard_tunnel_name_hint">Tunnel name in Wireguard</string>
+    <string name="o_wireguard_tunnel_state">Tunnel State</string>
+    <array name="o_wireguard_tunnel_states">
+        <item>Up</item>
+        <item>Down</item>
+    </array>
+
     <!--USource (us)-->
 
     <string name="usource__enabled_yes">Yes</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Oct 20 15:43:41 BST 2019
+#Sat Apr 24 11:28:46 CDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip


### PR DESCRIPTION
Adds the Wireguard operation which supports turning on or off a tunnel with
a given name.

Bumping gradle was required to use `<queries>` in the manifest.

Closes #361