### PR TITLE
Add Action & Data on launch_app

### DIFF
--- a/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppLoader.java
+++ b/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppLoader.java
@@ -43,6 +43,10 @@ public class LaunchAppLoader extends OperationLoader<LaunchAppOperationData> {
             intent = new Intent();
             intent.setComponent(new ComponentName(data.app_package, data.app_class));
         }
+        if (!Utils.isBlank(data.app_action))
+            intent.setAction(data.app_action);
+        if (!Utils.isBlank(data.app_data))
+            intent.setData(data.app_data);
         if (intent != null) {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             if (data.extras != null)

--- a/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppOperationData.java
+++ b/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppOperationData.java
@@ -20,6 +20,7 @@
 package ryey.easer.skills.operation.launch_app;
 
 import android.os.Parcel;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -40,15 +41,21 @@ public class LaunchAppOperationData implements OperationData {
     private static final String K_APP_PACKAGE = "package";
     private static final String K_CLASS = "class";
     private static final String K_EXTRAS = "extras";
+    private static final String K_ACTION = "action";
+    private static final String K_DATA = "data";
 
     final String app_package; //FIXME: @Nonnull???
     final @Nullable String app_class;
     final @Nullable Extras extras;
+    final @Nullable String app_action;
+    final @Nullable Uri app_data;
 
-    LaunchAppOperationData(String app_package, @Nullable String app_class, @Nullable Extras extras) {
+    LaunchAppOperationData(String app_package, @Nullable String app_class, @Nullable Extras extras, @Nullable String app_action, @Nullable Uri app_data) {
         this.app_package = app_package;
         this.app_class = app_class;
         this.extras = extras;
+        this.app_action = app_action;
+        this.app_data = app_data;
     }
 
     LaunchAppOperationData(@NonNull String data, @NonNull PluginDataFormat format, int version) throws IllegalStorageDataException {
@@ -59,6 +66,11 @@ public class LaunchAppOperationData implements OperationData {
                     app_package = jsonObject.getString(K_APP_PACKAGE);
                     app_class = jsonObject.optString(K_CLASS);
                     extras = Extras.mayParse(jsonObject.optString(K_EXTRAS), format, version);
+                    app_action = jsonObject.optString(K_ACTION);
+                    String data_s = jsonObject.optString(K_DATA);
+                    if (data_s != null) {
+                        app_data = Uri.parse(data_s);
+                    }
                 } catch (JSONException e) {
                     throw new IllegalStorageDataException(e);
                 }
@@ -77,6 +89,8 @@ public class LaunchAppOperationData implements OperationData {
                     jsonObject.put(K_CLASS, app_class);
                     if (extras != null)
                         jsonObject.put(K_EXTRAS, extras.serialize(format));
+                    jsonObject.put(K_ACTION, app_action);
+                    jsonObject.put(K_DATA, app_data.toString());
                     ret = jsonObject.toString();
                 } catch (JSONException e) {
                     throw new IllegalStateException(e);
@@ -104,6 +118,10 @@ public class LaunchAppOperationData implements OperationData {
             return false;
         if (!Utils.nullableEqual(extras, ((LaunchAppOperationData) obj).extras))
             return false;
+        if (!Utils.nullableEqual(app_action, ((LaunchAppOperationData) obj).app_action))
+            return false;
+        if (!Utils.nullableEqual(app_data, ((LaunchAppOperationData) obj).app_data))
+            return false;
         return true;
     }
 
@@ -117,6 +135,8 @@ public class LaunchAppOperationData implements OperationData {
         dest.writeString(app_package);
         dest.writeString(app_class);
         dest.writeParcelable(extras, 0);
+        dest.writeString(app_action);
+        dest.writeParcelable(app_data, 0);
     }
 
     public static final Creator<LaunchAppOperationData> CREATOR
@@ -134,6 +154,8 @@ public class LaunchAppOperationData implements OperationData {
         app_package = in.readString();
         app_class = in.readString();
         extras = in.readParcelable(Extras.class.getClassLoader());
+        app_action = in.readString();
+        app_data = in.readParcelable(Uri.class.getClassLoader());
     }
 
     @Nullable

--- a/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppOperationDataFactory.java
+++ b/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppOperationDataFactory.java
@@ -37,7 +37,7 @@ class LaunchAppOperationDataFactory implements OperationDataFactory<LaunchAppOpe
     @NonNull
     @Override
     public LaunchAppOperationData dummyData() {
-        return new LaunchAppOperationData("com.dummy.app.package", "com.dummy.app.package.Activity1", null);
+        return new LaunchAppOperationData("com.dummy.app.package", "com.dummy.app.package.Activity1", null, null, null);
     }
 
     @ValidData

--- a/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppSkillViewFragment.java
+++ b/app/src/main/java/ryey/easer/skills/operation/launch_app/LaunchAppSkillViewFragment.java
@@ -38,6 +38,8 @@ public class LaunchAppSkillViewFragment extends SkillViewFragment<LaunchAppOpera
     EditText et_app_package;
     EditText et_class;
     EditExtraFragment editExtraFragment;
+    EditText et_app_action;
+    EditText et_app_data;
 
     @NonNull
     @Override
@@ -46,6 +48,8 @@ public class LaunchAppSkillViewFragment extends SkillViewFragment<LaunchAppOpera
         et_app_package = view.findViewById(R.id.editText_app_package);
         et_class = view.findViewById(R.id.editText_app_activity);
         editExtraFragment = (EditExtraFragment) getChildFragmentManager().findFragmentById(R.id.fragment_edit_extra);
+        et_app_action = view.findViewById(R.id.editText_app_action);
+        et_app_data = view.findViewById(R.id.editText_app_data);
         return view;
     }
 
@@ -54,12 +58,14 @@ public class LaunchAppSkillViewFragment extends SkillViewFragment<LaunchAppOpera
         et_app_package.setText(data.app_package);
         et_class.setText(data.app_class);
         editExtraFragment.fillExtras(data.extras);
+        et_app_action.setText(data.app_action);
+        et_app_data.setText(data.app_data.toString());
     }
 
     @ValidData
     @NonNull
     @Override
     public LaunchAppOperationData getData() throws InvalidDataInputException {
-        return new LaunchAppOperationData(et_app_package.getText().toString(), et_class.getText().toString(), editExtraFragment.getExtras());
+        return new LaunchAppOperationData(et_app_package.getText().toString(), et_class.getText().toString(), editExtraFragment.getExtras(), et_app_action.getText().toString(), Uri.parse(et_app_data.getText().toString()));
     }
 }

--- a/app/src/main/res/layout/skill_operation__launch_app.xml
+++ b/app/src/main/res/layout/skill_operation__launch_app.xml
@@ -84,6 +84,60 @@
         app:layout_constraintStart_toEndOf="@+id/textView53"
         app:layout_constraintTop_toBottomOf="@+id/editText_app_package" />
 
+    <TextView
+        android:id="@+id/textView54"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:text="@string/o_launch_app__text_action"
+        app:layout_constraintBottom_toBottomOf="@+id/editText_app_action"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/editText_app_action" />
+
+    <EditText
+        android:id="@+id/editText_app_action"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:ems="10"
+        android:hint="@string/o_launch_app__text_action_hint"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/textView54"
+        app:layout_constraintTop_toBottomOf="@+id/editText_app_activity" />
+
+    <TextView
+        android:id="@+id/textView55"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:text="@string/o_launch_app__text_data"
+        app:layout_constraintBottom_toBottomOf="@+id/editText_app_data"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/editText_app_data" />
+
+    <EditText
+        android:id="@+id/editText_app_data"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:ems="10"
+        android:hint="@string/o_launch_app__text_data_hint"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/textView55"
+        app:layout_constraintTop_toBottomOf="@+id/editText_app_action" />
+
     <fragment
         android:id="@+id/fragment_edit_extra"
         android:name="ryey.easer.skills.reusable.EditExtraFragment"
@@ -95,6 +149,6 @@
         android:layout_marginRight="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/editText_app_activity" />
+        app:layout_constraintTop_toBottomOf="@+id/editText_app_data" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-zh/plugins.xml
+++ b/app/src/main/res/values-zh/plugins.xml
@@ -174,6 +174,10 @@
     <string name="op_launch_app_text_app_hint">包名</string>
     <string name="o_launch_app__text_class">類名</string>
     <string name="o_launch_app__text_class_hint">空白或完整類名</string>
+    <string name="o_launch_app__text_action">事件</string>
+    <string name="o_launch_app__text_action_hint">空白或事件名</string>
+    <string name="o_launch_app__text_data">數據</string>
+    <string name="o_launch_app__text_data_hint">空白或Uri</string>
     <string name="op_ui_mode">UI模式</string>
     <string name="op_car_mode">車載模式</string>
     <string name="op_normal_mode">普通模式</string>

--- a/app/src/main/res/values/plugins.xml
+++ b/app/src/main/res/values/plugins.xml
@@ -148,6 +148,10 @@
     <string name="op_launch_app_text_app_hint">Package Name</string>
     <string name="o_launch_app__text_class">Class Name</string>
     <string name="o_launch_app__text_class_hint">Empty or full class name</string>
+    <string name="o_launch_app__text_action">Action</string>
+    <string name="o_launch_app__text_action_hint">Empty or Action name</string>
+    <string name="o_launch_app__text_data">Data</string>
+    <string name="o_launch_app__text_data_hint">Empty or Uri</string>
 
     <string name="operation_media_control">Media Control</string>
     <string name="text_play_pause">Toogle play/pause</string>


### PR DESCRIPTION
For random APP's shortcut action (hold the icon on luncher then see the shortcut menu), it start with special action and data_url. It works with adb like:
```bash
am start -a com.example.action.shortcut -d ui://example/home com.example/example.ui.welcom
```
But there's no way to set both `package` and (`action` or `data`) with `Launch App` or `Start Activity` plugin