### PR TITLE
add RUN_COMMAND for Termux AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <uses-permission android:name="com.wireguard.android.permission.CONTROL_TUNNELS"/>
-
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND"  />
+    
     <application
         android:name=".EaserApplication"
         android:allowBackup="true"


### PR DESCRIPTION
This (along with properly configuring Termux (`allow-external-apps = true` in the termux.properties file)) should allow Easer to run Termux commands without workarounds. As mentioned in #415 , this can be done with the Run Commands profile, but it would be nice to eventually have a dedicated Run Termux Commands profile.