### PR TITLE
Fix typo for CATEGORY_NOTIFY_SLOT string

### DIFF
--- a/app/src/main/java/ryey/easer/skills/event/SelfNotifiableSlot.java
+++ b/app/src/main/java/ryey/easer/skills/event/SelfNotifiableSlot.java
@@ -40,7 +40,7 @@ public abstract class SelfNotifiableSlot<T extends EventData> extends AbstractSl
     // Fields used in relevant Intent
     private static final String ACTION_SATISFIED = "ryey.easer.triggerlotus.abstractslot.SATISFIED";
     private static final String ACTION_UNSATISFIED = "ryey.easer.triggerlotus.abstractslot.UNSATISFIED";
-    private static final String CATEGORY_NOTIFY_SLOT = "ryey.easer.triggetlotus.category.NOTIFY_SLOT";
+    private static final String CATEGORY_NOTIFY_SLOT = "ryey.easer.triggerlotus.category.NOTIFY_SLOT";
     /*
      * Mechanisms and fields used to notify the slot itself, and then proceed to `onPositiveNotified()`.
      * This is because some system-level checking mechanisms (e.g. data/time) need a PendingIntent.


### PR DESCRIPTION
Hi, thank you for this open source software. Actually with this PR I was intending to fix the problem of notification event that does not trigger the profile action, the problem was the `listen()` and `cancel()` not calling its super method. But then I've made a big overlook. 

It was already fixed in beta branch. I think the beta release should be updated & APK should be built and put under the release assets for the `v0.8.3-beta3` tag so there aren't others like me refixing the wheel. 

But I found a typo, so I made this PR anyways.