### PR TITLE
Fix crash on Android O in StickyListHeaders

### DIFF
--- a/app/src/main/res/layout/fragment_dialog_select_skill.xml
+++ b/app/src/main/res/layout/fragment_dialog_select_skill.xml
@@ -11,10 +11,13 @@
         android:layout_height="wrap_content"
         android:text="@string/title_select_operation" />
 
+    <!-- https://github.com/emilsjolander/StickyListHeaders/issues/477 -->
     <se.emilsjolander.stickylistheaders.StickyListHeadersListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:divider="@color/colorDivider"
-        android:dividerHeight="1dp" />
+        android:dividerHeight="1dp"
+        android:importantForAutofill="noExcludeDescendants"
+        android:saveEnabled="false" />
 </LinearLayout>


### PR DESCRIPTION
There is a bug in StickyListHeaders which causes a crash "IllegalStateException: Handling non empty state of parent class is not implemented" on new versions of Android - https://github.com/emilsjolander/StickyListHeaders/issues/477

This occurs, for example, in the Bluetooth devices list. The fix, described in the above linked GitHub issue, is to disable autofill and saving.